### PR TITLE
Added command to disable bumps on R2+ renderers

### DIFF
--- a/src/Layers/xrRender/uber_deffer.cpp
+++ b/src/Layers/xrRender/uber_deffer.cpp
@@ -11,7 +11,7 @@ void	uber_deffer	(CBlender_Compile& C, bool hq, LPCSTR _vspec, LPCSTR _pspec, BO
 	xr_strcpy			(fname,*C.L_textures[0]);	//. andy if (strext(fname)) *strext(fname)=0;
 	fix_texture_name(fname);
 	ref_texture		_t;		_t.create			(fname);
-	bool			bump	= _t.bump_exist		();
+	bool			bump = ps_r__common_flags.test(R2FLAG_USE_BUMP) && _t.bump_exist();
 
 	// detect lmap
 	bool			lmap	= true;

--- a/src/Layers/xrRender/xrRender_console.cpp
+++ b/src/Layers/xrRender/xrRender_console.cpp
@@ -844,6 +844,7 @@ void		xrRender_initconsole	()
 
 	CMD3(CCC_Mask,		"r2_steep_parallax",			&ps_r2_ls_flags,			R2FLAG_STEEP_PARALLAX);
 	CMD3(CCC_Mask,		"r2_detail_bump",				&ps_r2_ls_flags,			R2FLAG_DETAIL_BUMP);
+	CMD3(CCC_Mask,		"r2_use_bump",					&ps_r__common_flags,		R2FLAG_USE_BUMP);
 
 	CMD3(CCC_Token,		"r2_sun_quality",				&ps_r_sun_quality,			qsun_quality_token);
 

--- a/src/Layers/xrRender/xrRender_console.h
+++ b/src/Layers/xrRender/xrRender_console.h
@@ -192,6 +192,7 @@ enum
 	R_FLAGEXT_HOM_DEPTH_DRAW		= (1<<7),
 	R2FLAGEXT_SUN_ZCULLING			= (1<<8),
 	RFLAG_ACTOR_SHADOW				= (1<<9),
+	R2FLAG_USE_BUMP					= (1<<10),
 };
 
 extern void						xrRender_initconsole	();


### PR DESCRIPTION
Proposed changes:

- Added `r2_use_bump` command to disable bumps on R2+ renderers

Agreements:

- [x] I agree to follow this project's [__Contributing Guidelines__](https://github.com/ixray-team/.github/blob/default/CONTRIBUTING.md)
- [x] I agree to follow this project's [__Code of Conduct__](https://github.com/ixray-team/.github/blob/default/CODE_OF_CONDUCT.md)
