### PR TITLE
Add boundaries to cam_inert console-command

### DIFF
--- a/src/xrEngine/xr_ioc_cmd.cpp
+++ b/src/xrEngine/xr_ioc_cmd.cpp
@@ -790,7 +790,7 @@ void CCC_Register()
 	CMD4(CCC_Float,		"mouse_sens",			&psMouseSens,		0.001f, 0.6f);
 
 	// Camera
-	CMD2(CCC_Float,		"cam_inert",			&psCamInert);
+	CMD4(CCC_Float, "cam_inert", &psCamInert, 0.0f, 0.9f);
 	CMD2(CCC_Float,		"cam_slide_inert",		&psCamSlideInert);
 
 	CMD1(CCC_r2,		"renderer"				);


### PR DESCRIPTION
It fixes camera bug which occurs when `cam_inert > 0.9`

Proposed changes:

- Added boundaries to cam_inert console-command

Agreements:

- [x] I agree to follow this project's [__Contributing Guidelines__](https://github.com/ixray-team/.github/blob/default/CONTRIBUTING.md)
- [x] I agree to follow this project's [__Code of Conduct__](https://github.com/ixray-team/.github/blob/default/CODE_OF_CONDUCT.md)