### PR TITLE
Fixed bones synchronization

### DIFF
--- a/src/xrGame/PHSkeleton.cpp
+++ b/src/xrGame/PHSkeleton.cpp
@@ -267,10 +267,17 @@ void CPHSkeleton::RestoreNetState(CSE_PHSkeleton* po)
 			obj->PHGetSyncItem(bone)->set_State(*i);
 		}
 	saved_bones.clear();
+	ClearSavedBones();
 	po->_flags.set(CSE_PHSkeleton::flSavedData,FALSE);
 	m_flags.set(CSE_PHSkeleton::flSavedData,FALSE);
 }
 
+void CPHSkeleton::ClearSavedBones()
+{
+	NET_Packet P;
+	CGameObject::u_EventGen(P, GE_CLEAR_SAVED_BONES, PPhysicsShellHolder()->ID());
+	CGameObject::u_EventSend(P);
+}
 
 void CPHSkeleton::ClearUnsplited()
 {

--- a/src/xrGame/PHSkeleton.h
+++ b/src/xrGame/PHSkeleton.h
@@ -1,5 +1,4 @@
-#ifndef PH_SKELETON_H
-#define PH_SKELETON_H
+#pragma once
 
 #include "../xrphysics/PHDefs.h"
 #include "PHDestroyableNotificate.h"
@@ -33,6 +32,7 @@ private:
 	//Autoremove
 	bool	ReadyForRemove		()																				;
 	void	RecursiveBonesCheck	(u16 id)																		;
+	void ClearSavedBones();
 
 protected:
 	void			LoadNetState		(NET_Packet& P)															;
@@ -59,5 +59,3 @@ IC			bool	IsRemoving			(){return b_removing;}
 					CPHSkeleton			()																		;
 	virtual			~CPHSkeleton		()																		;
 };
-
-#endif

--- a/src/xrGame/xrServer_process_event.cpp
+++ b/src/xrGame/xrServer_process_event.cpp
@@ -38,6 +38,13 @@ void xrServer::Process_event	(NET_Packet& P, ClientID sender)
 
 	switch		(type)
 	{
+	case GE_CLEAR_SAVED_BONES:
+	{
+		const auto po = smart_cast<CSE_PHSkeleton*>(receiver);
+		R_ASSERT(po);
+		po->saved_bones.bones.clear();
+		break;
+	}
 	case GE_GAME_EVENT:
 		{
 			u16		game_event_type;

--- a/src/xrServerEntities/xrMessages.h
+++ b/src/xrServerEntities/xrMessages.h
@@ -1,6 +1,3 @@
-#ifndef _INCDEF_XRMESSAGES_H_
-#define _INCDEF_XRMESSAGES_H_
-
 #pragma once
 
 // CL	== client 2 server message
@@ -159,6 +156,7 @@ enum {
 	
 	GEG_PLAYER_USE_BOOSTER,
 	GE_REQUEST_PLAYERS_INFO,
+	GE_CLEAR_SAVED_BONES,
 
 	GE_FORCEDWORD				= u32(-1)
 };
@@ -254,6 +252,3 @@ enum enum_connection_results
 	ecr_have_been_banned,
 	ecr_profile_error,
 };//enum enum_connection_results
-
-
-#endif /*_INCDEF_XRMESSAGES_H_*/


### PR DESCRIPTION
Proposed changes:

- Fixed bones synchronization

Cleanup of `saved_bones` was performed not on `CSE_PHSkeleton` object itself, but only on its copy. Therefore `saved_bones.clear()` was not reflected on the server object. The fix works both in single and multiplayer

Agreements:

- [x] I agree to follow this project's [__Contributing Guidelines__](https://github.com/ixray-team/.github/blob/default/CONTRIBUTING.md)
- [x] I agree to follow this project's [__Code of Conduct__](https://github.com/ixray-team/.github/blob/default/CODE_OF_CONDUCT.md)