### PR TITLE
Многопоточная регистрация space restrictor'ов

### DIFF
--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -109,7 +109,7 @@ void register_mp_console_commands();
 
 		BOOL	g_bCheckTime			= FALSE;
 		int		net_cl_inputupdaterate	= 50;
-		Flags32	g_mt_config				= {mtLevelPath | mtDetailPath | mtObjectHandler | mtSoundPlayer | mtAiVision | mtBullets | mtLUA_GC | mtLevelSounds | mtALife | mtMap};
+		Flags32	g_mt_config				= {mtLevelPath | mtDetailPath | mtObjectHandler | mtSoundPlayer | mtAiVision | mtBullets | mtLUA_GC | mtLevelSounds | mtALife | mtMap | mtRestrictors};
 #ifdef DEBUG_DRAW
 		Flags32	dbg_net_Draw_Flags		= {0};
 #endif
@@ -1959,6 +1959,7 @@ void CCC_RegisterCommands()
 	CMD3(CCC_Mask,				"mt_level_sounds",		&g_mt_config,	mtLevelSounds);
 	CMD3(CCC_Mask,				"mt_alife",				&g_mt_config,	mtALife);
 	CMD3(CCC_Mask,				"mt_map",				&g_mt_config,	mtMap);
+	CMD3(CCC_Mask,				"mt_restrictors",		&g_mt_config,	mtRestrictors);
 #endif // MASTER_GOLD
 
 #ifndef MASTER_GOLD

--- a/src/xrGame/mt_config.h
+++ b/src/xrGame/mt_config.h
@@ -20,3 +20,4 @@ extern	Flags32				g_mt_config;
 #define mtLevelSounds		(1<<7)
 #define mtALife				(1<<8)
 #define mtMap				(1<<9)
+#define mtRestrictors		(1<<10)

--- a/src/xrGame/space_restriction_holder.cpp
+++ b/src/xrGame/space_restriction_holder.cpp
@@ -134,16 +134,19 @@ void CSpaceRestrictionHolder::register_restrictor				(CSpaceRestrictor *space_re
 		if (xr_strcmp(*temp,temp1))
 			on_default_restrictions_changed	();
 	}
-	
+
 	CSpaceRestrictionShape	*shape = xr_new<CSpaceRestrictionShape>(space_restrictor,restrictor_type != RestrictionSpace::eDefaultRestrictorTypeNone);
+	m_lock.Enter();
+
 	RESTRICTIONS::iterator	I = m_restrictions.find(space_restrictors);
 	if (I == m_restrictions.end()) {
 		CSpaceRestrictionBridge	*bridge = xr_new<CSpaceRestrictionBridge>(shape);
 		m_restrictions.insert	(std::make_pair(space_restrictors,bridge));
+		m_lock.Leave();
 		return;
 	}
-
 	(*I).second->change_implementation(shape);
+	m_lock.Leave();
 }
 
 bool try_remove_string				(shared_str &search_string, const shared_str &string_to_search)

--- a/src/xrGame/space_restriction_holder.h
+++ b/src/xrGame/space_restriction_holder.h
@@ -19,14 +19,15 @@ namespace RestrictionSpace {
 };
 
 namespace SpaceRestrictionHolder {
-	typedef intrusive_ptr<CSpaceRestrictionBridge,RestrictionSpace::CTimeIntrusiveBase> CBaseRestrictionPtr;
+	using CBaseRestrictionPtr = intrusive_ptr<CSpaceRestrictionBridge,RestrictionSpace::CTimeIntrusiveBase>;
 };
 
 class CSpaceRestrictionHolder {
 public:
-	typedef xr_map<shared_str,CSpaceRestrictionBridge*>	RESTRICTIONS;
+	using RESTRICTIONS = xr_map<shared_str,CSpaceRestrictionBridge*>;
 
 private:
+	xrCriticalSection m_lock;
 	enum {
 		MAX_RESTRICTION_PER_TYPE_COUNT	= u32(128),
 		dummy							= u32(-1),


### PR DESCRIPTION
При загрузке оригинальных ЗП локаций уменьшает время загрузки на 2-3 секунды (без мт загрузка длится 7-9 секунд)
На локациях с огромным количеством ai-нодов и рестрикторов прирост куда более ощутимый: загрузка локации в just online упала с 4 минут до 40 секунд.