### PR TITLE
Hashed alpha testing

### DIFF
--- a/gamedata/configs/ui/ui_mm_opt.xml
+++ b/gamedata/configs/ui/ui_mm_opt.xml
@@ -303,6 +303,14 @@
             <options_item entry="r4_hud_shadows" group="mm_opt_video" depend="vid"/>
         </check_r4_hud_shadows>
 
+        <cap_r4_hashed_aref x="20" y="3" width="135" height="24">
+            <text r="170" g="170" b="170" font="letterica16" align="r" vert_align="c">ui_mm_r4_hashed_aref</text>
+        </cap_r4_hashed_aref>
+        <check_r4_hashed_aref x="167" y="0" width="44" height="29">
+            <texture>ui_inGame2_checkbox</texture>
+            <options_item entry="r4_hashed_alpha_test" group="mm_opt_video"/>
+        </check_r4_hashed_aref>
+
         <cap_r2_cloud_shadows x="20" y="3" width="135" height="24">
             <text r="170" g="170" b="170" font="letterica16" align="r" vert_align="c">ui_mm_r2_cloud_shadows</text>
         </cap_r2_cloud_shadows>

--- a/gamedata/configs/ui/ui_mm_opt_16.xml
+++ b/gamedata/configs/ui/ui_mm_opt_16.xml
@@ -306,6 +306,14 @@
             <options_item entry="r4_hud_shadows" group="mm_opt_video" depend="vid"/>
         </check_r4_hud_shadows>
 
+        <cap_r4_hashed_aref x="16" y="3" width="108" height="24">
+            <text r="170" g="170" b="170" font="letterica16" align="r" vert_align="c">ui_mm_r4_hashed_aref</text>
+        </cap_r4_hashed_aref>
+        <check_r4_hashed_aref x="133" y="0" width="35" stretch="1" height="29">
+            <texture>ui_inGame2_checkbox</texture>
+            <options_item entry="r4_hashed_alpha_test" group="mm_opt_video"/>
+        </check_r4_hashed_aref>
+
         <cap_r2_cloud_shadows x="16" y="3" width="108" height="24">
             <text r="170" g="170" b="170" font="letterica16" align="r" vert_align="c">ui_mm_r2_cloud_shadows</text>
         </cap_r2_cloud_shadows>

--- a/gamedata/scripts/ui_mm_opt_video_adv.script
+++ b/gamedata/scripts/ui_mm_opt_video_adv.script
@@ -94,6 +94,11 @@ function opt_video_adv:InitControls(x, y, xml, handler)
     table.insert(handler.m_preconditions, {func=mode_4, control=_st})
 
     _st = xml:InitStatic("video_adv:templ_item", nil)
+    xml:InitStatic("video_adv:cap_r4_hashed_aref", _st)
+    ctl = xml:InitCheck ("video_adv:check_r4_hashed_aref", _st)
+    table.insert(handler.m_preconditions, {func=mode_4, control=_st})
+
+    _st = xml:InitStatic("video_adv:templ_item", nil)
     xml:InitStatic("video_adv:cap_r_actor_shadow", _st)
     ctl = xml:InitCheck ("video_adv:check_r_actor_shadow", _st)
     table.insert(handler.m_preconditions, {func=all_modes, control=_st})

--- a/gamedata/shaders/r3/deffer_base.ps
+++ b/gamedata/shaders/r3/deffer_base.ps
@@ -11,7 +11,11 @@ void main (p_bumped_new I, out f_deffer O) {
 	SloadNew(I, M);
 	
 #ifdef USE_AREF
-	clip(M.Color.w - def_aref);
+	#ifdef USE_HASHED_AREF
+		clip(M.Color.w - hashed_alpha_test(M.point));
+	#else
+		clip(M.Color.w - def_aref);
+	#endif	
 #endif
 	
 	M.Normal = mul(float3x3(I.M1, I.M2, I.M3), M.Normal);

--- a/gamedata/shaders/r3/deffer_base.ps
+++ b/gamedata/shaders/r3/deffer_base.ps
@@ -12,7 +12,7 @@ void main (p_bumped_new I, out f_deffer O) {
 	
 #ifdef USE_AREF
 	#ifdef USE_HASHED_AREF
-		clip(M.Color.w - hashed_alpha_test(M.point));
+		clip(M.Color.w - hashed_alpha_test(M.Point));
 	#else
 		clip(M.Color.w - def_aref);
 	#endif	

--- a/gamedata/shaders/r3/forward_base.ps
+++ b/gamedata/shaders/r3/forward_base.ps
@@ -15,7 +15,11 @@ void main (p_bumped_new I, out f_forward O) {
 	SloadNew(I, M);
 	
 #ifdef USE_AREF
-	clip(M.Color.w - def_aref);
+	#ifdef USE_HASHED_AREF
+		clip(M.Color.w - hashed_alpha_test(M.point));
+	#else
+		clip(M.Color.w - def_aref);
+	#endif
 #endif
 	
 	M.Normal = mul(float3x3(I.M1, I.M2, I.M3), M.Normal);

--- a/gamedata/shaders/r3/forward_base.ps
+++ b/gamedata/shaders/r3/forward_base.ps
@@ -16,7 +16,7 @@ void main (p_bumped_new I, out f_forward O) {
 	
 #ifdef USE_AREF
 	#ifdef USE_HASHED_AREF
-		clip(M.Color.w - hashed_alpha_test(M.point));
+		clip(M.Color.w - hashed_alpha_test(M.Point));
 	#else
 		clip(M.Color.w - def_aref);
 	#endif

--- a/src/Layers/xrRender/Blender_Recorder_StandartBinding.cpp
+++ b/src/Layers/xrRender/Blender_Recorder_StandartBinding.cpp
@@ -271,7 +271,7 @@ static cl_hud_project binder_hud_project;
 class cl_taa_jitter : public R_constant_setup {
 	virtual void setup(R_constant* C) {
 		Fvector& V = ps_r_taa_jitter;
-		RCache.set_c(C, V.x, V.y, V.z, 0);
+		RCache.set_c(C, V.x, V.y, V.z, float(RDEVICE.dwFrame));
 	}
 };
 static cl_taa_jitter binder_taa_jitter;

--- a/src/Layers/xrRender/xrRender_console.cpp
+++ b/src/Layers/xrRender/xrRender_console.cpp
@@ -165,6 +165,7 @@ Flags32		ps_r2_ls_flags_ext			= {
 	R2FLAGEXT_SSAO_HALF_DATA
 	| R2FLAGEXT_ENABLE_TESSELLATION
 	| R4FLAG_SCREEN_SPACE_HUD_SHADOWS
+	| R4FLAG_HASHED_ALPHA_TEST
 };
 
 Flags32 ps_r__common_flags = { R2FLAG_USE_BUMP | RFLAG_USE_CACHE | RFLAG_NO_RAM_TEXTURES | RFLAG_MT_TEX_LOAD };
@@ -854,6 +855,8 @@ void		xrRender_initconsole	()
 	CMD3(CCC_Mask,		"r2_dof_enable",&ps_r2_ls_flags,	R2FLAG_DOF);
 
 	CMD3(CCC_Mask,		"r4_hud_shadows",				&ps_r2_ls_flags_ext,		R4FLAG_SCREEN_SPACE_HUD_SHADOWS);
+
+	CMD3(CCC_Mask,		"r4_hashed_alpha_test",			&ps_r2_ls_flags_ext,		R4FLAG_HASHED_ALPHA_TEST);
 
 	CMD3(CCC_Mask,		"r2_volumetric_lights",			&ps_r2_ls_flags,			R2FLAG_VOLUMETRIC_LIGHTS);
 //	CMD3(CCC_Mask,		"r2_sun_shafts",				&ps_r2_ls_flags,			R2FLAG_SUN_SHAFTS);

--- a/src/Layers/xrRender/xrRender_console.h
+++ b/src/Layers/xrRender/xrRender_console.h
@@ -205,6 +205,7 @@ enum
 	RFLAG_MT_TEX_LOAD     = (1 << 13),
 	RFLAG_OPT_SHAD_GEOM = (1 << 15),
 	R4FLAG_SCREEN_SPACE_HUD_SHADOWS = (1 << 16),
+	R4FLAG_HASHED_ALPHA_TEST = (1 << 17),
 };
 
 extern void						xrRender_initconsole	();

--- a/src/Layers/xrRenderPC_R4/r4.cpp
+++ b/src/Layers/xrRenderPC_R4/r4.cpp
@@ -1021,6 +1021,19 @@ HRESULT	CRender::shader_compile			(
 		++len;
 	}
 
+	if (ps_r2_ls_flags_ext.test(R4FLAG_HASHED_ALPHA_TEST))
+	{
+		defines[def_it].Name = "USE_HASHED_AREF";
+		defines[def_it].Definition = "1";
+		def_it ++;
+		sh_name[len]='1'; ++len;
+	}
+	else
+	{
+		sh_name[len] = '0';
+		++len;
+	}
+
 	if (ps_r_sun_shafts)
 	{
 		xr_sprintf					(c_sun_shafts,"%d",ps_r_sun_shafts);


### PR DESCRIPTION
Hashed Alpha Testing implementation by Chris Wyman and Morgan McGuire. 
Based on https://cwyman.org/papers/i3d17_hashedAlpha.pdf

Few remarks:
- We do not use world space position of the object, instead the view pos is used.
- We do not take anisotropy into account, though it is possible to extend the algorithm in the future.
- R1 sequence should be enabled upon FSR/DLSS/TAA detection, to further mitigrate noise.
- The code introduces more overhead and should remain as optional feature.

