### PR TITLE
* [Editors] Заменил в пропах флаг 'ImGuiTableFlags_NoBordersInBody' на флаг 'ImGuiTableFlags_NoBordersInBodyUntilResize'.

### DIFF
--- a/src/Editors/xrEProps/Tree/Properties/UIPropertiesForm.cpp
+++ b/src/Editors/xrEProps/Tree/Properties/UIPropertiesForm.cpp
@@ -92,7 +92,7 @@ void UIPropertiesForm::Draw()
 		}
 	}
 
-	static ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_BordersOuterH | ImGuiTableFlags_Resizable | ImGuiTableFlags_RowBg | ImGuiTableFlags_NoBordersInBody;
+    static ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_BordersOuterH | ImGuiTableFlags_Resizable | ImGuiTableFlags_RowBg | ImGuiTableFlags_NoBordersInBodyUntilResize;
 	if (ImGui::BeginTable("props", 2, flags))
 	{
 		ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_NoHide);


### PR DESCRIPTION

### Proposed changes / Предлагаемые изменения

<!--
Please insert the list of changes below. For example:
Пожалуйста, вставьте список изменений ниже. Например:

- Added some functionality / Добавлена некоторая функциональность
- Deleted old things / Удалены старые вещи
- Fixed bug_name bug / Исправлен баг bug_name
-->

- Замена в пропах флага 'ImGuiTableFlags_NoBordersInBody' на флаг 'ImGuiTableFlags_NoBordersInBodyUntilResize', что бы можно было изменять размер столбцов в пропах в любом месте, а не только в заголовке, а то напрягает, когда надо пододвинуть где нибудь - и приходится листать в самый верх.

### Associated issues / Ассоциированные проблемы

<!--
If this pull request is associated with any issue, then put its number here
please. For example:
Если этот запрос на извлечение связан с какой-либо проблемой, пожалуйста,
укажите его номер здесь. Например:

- #8
-->

- 

### Testing / Тестирование

<!--
Please write 'x' letter in '[]' to agree. For example:
Пожалуйста, напишите букву 'x' в '[]' для подтверждения. Например:

- [x] Manual testing / Ручное тестирование
-->

- [ ] Manual testing / Ручное тестирование

### Agreements / Согласия

- I agree to follow this project's [__Contributing Guidelines__](../CONTRIBUTING.md) /
Я согласен(-на) следовать [__Рекомендациям по внесению вклада в этот проект__](../CONTRIBUTING.rus.md)
- I agree to follow this project's [__Code of Conduct__](../CODE_OF_CONDUCT.md) /
Я согласен(-на) следовать [__Кодексу поведения этого проекта__](../CODE_OF_CONDUCT.rus.md)
