### PR TITLE
Fix name output of missing THM during spawn compilation

### DIFF
--- a/src/utils/xrAI/compiler_load.cpp
+++ b/src/utils/xrAI/compiler_load.cpp
@@ -157,7 +157,7 @@ void xrLoad(LPCSTR name, bool draft_mode)
 						IReader* THM	= FS.r_open("$game_textures$",N_);
 
 						if (!THM) {
-							clMsg("cannot find thm: %s", N);
+							clMsg("cannot find thm: %s", N_);
 							is_thm_missing = true;
 							continue;
 						}


### PR DESCRIPTION
### Proposed changes / Предлагаемые изменения

- Исправлено выведение имени отсутствующего .THM файла при сборке спавна.

### Associated issues / Ассоциированные проблемы

- 

### Testing / Тестирование

- [ ] Manual testing / Ручное тестирование

### Agreements / Согласия

- I agree to follow this project's [__Contributing Guidelines__](../CONTRIBUTING.md) /
Я согласен(-на) следовать [__Рекомендациям по внесению вклада в этот проект__](../CONTRIBUTING.rus.md)
- I agree to follow this project's [__Code of Conduct__](../CODE_OF_CONDUCT.md) /
Я согласен(-на) следовать [__Кодексу поведения этого проекта__](../CODE_OF_CONDUCT.rus.md)
