### PR TITLE
Undo/Redo buttons fixed

### DIFF
--- a/src/Editors/LevelEditor/UI/UITopBarForm.cpp
+++ b/src/Editors/LevelEditor/UI/UITopBarForm.cpp
@@ -5,7 +5,9 @@
 UITopBarForm::UITopBarForm()
 {
     m_tUndo                  = EDevice->Resources->_CreateTexture("ed\\bar\\Undo");
+    m_timeUndo               = 0;
     m_tRedo                  = EDevice->Resources->_CreateTexture("ed\\bar\\Redo");
+    m_timeRedo               = 0;
     m_tNew                   = EDevice->Resources->_CreateTexture("ed\\bar\\new");
     m_tOpen                  = EDevice->Resources->_CreateTexture("ed\\bar\\open");
     m_tSave                  = EDevice->Resources->_CreateTexture("ed\\bar\\save");


### PR DESCRIPTION
Добавил `m_timeUndo = 0` и `m_timeRedo = 0`, удаленные в [703b028](https://github.com/ixray-team/ixray-1.6-stcop/commit/703b028a3a62c3b58a64c0a8d74f21ca2114f034). Их забыли вернуть в фиксации [78ed091](https://github.com/ixray-team/ixray-1.6-stcop/commit/78ed0913fdfc2922ee5efa8c8c600401cc295627). Теперь кнопки работают корректно.