### PR TITLE
Fix sound dist

### DIFF
--- a/src/xrSound/SoundRender_Core_StartStop.cpp
+++ b/src/xrSound/SoundRender_Core_StartStop.cpp
@@ -32,6 +32,15 @@ void	CSoundRender_Core::i_start		(CSoundRender_Emitter* E)
 	E->target			= T;
 	E->target->start	(E);
 	T->priority			= Ptest;
+
+	//v2v3v4 in
+	if (E->target->get_emitter())
+	{
+		float	dist = SoundRender->listener_position().distance_to(E->target->get_emitter()->p_source.position);
+		if (dist > E->target->get_emitter()->p_source.max_distance && !E->target->get_emitter()->b2D)
+			E->target->get_emitter()->cancel();
+	}
+	//v2v3v4 out
 }
 
 void	CSoundRender_Core::i_stop		(CSoundRender_Emitter* E)

--- a/src/xrSound/SoundRender_Core_StartStop.cpp
+++ b/src/xrSound/SoundRender_Core_StartStop.cpp
@@ -32,15 +32,6 @@ void	CSoundRender_Core::i_start		(CSoundRender_Emitter* E)
 	E->target			= T;
 	E->target->start	(E);
 	T->priority			= Ptest;
-
-	//v2v3v4 in
-	if (E->target->get_emitter())
-	{
-		float	dist = SoundRender->listener_position().distance_to(E->target->get_emitter()->p_source.position);
-		if (dist > E->target->get_emitter()->p_source.max_distance && !E->target->get_emitter()->b2D)
-			E->target->get_emitter()->cancel();
-	}
-	//v2v3v4 out
 }
 
 void	CSoundRender_Core::i_stop		(CSoundRender_Emitter* E)

--- a/src/xrSound/SoundRender_Emitter_FSM.cpp
+++ b/src/xrSound/SoundRender_Emitter_FSM.cpp
@@ -221,7 +221,11 @@ IC void	volume_lerp(float& c, float t, float s, float dt)
 
 BOOL CSoundRender_Emitter::update_culling(float dt)
 {
-	
+	//LostAlphaRus in
+	float min_max = 1.f;
+	float volume_att = 1.f;
+	//LostAlphaRus out
+
 	if (b2D)
 	{
 		occluder_volume		= 1.f;
@@ -232,9 +236,19 @@ BOOL CSoundRender_Emitter::update_culling(float dt)
 		if (dist>p_source.max_distance)										{ smooth_volume = 0; return FALSE; }
 
 		// Calc attenuated volume
-		float att			= p_source.min_distance/(psSoundRolloff*dist);	clamp(att,0.f,1.f);
-		float fade_scale	= bStopping||(att*p_source.base_volume*p_source.volume*(owner_data->s_type==st_Effect?psSoundVEffects*psSoundVFactor:psSoundVMusic)<psSoundCull)?-1.f:1.f;
+		//LostAlphaRus in
+		min_max = p_source.max_distance - p_source.min_distance;
+		volume_att = (p_source.max_distance - dist) / min_max;
+		clamp(volume_att, 0.f, p_source.volume);
+
+		float fade_scale	= bStopping||(p_source.base_volume*p_source.volume*(owner_data->s_type==st_Effect?psSoundVEffects*psSoundVFactor:psSoundVMusic)<psSoundCull)?-1.f:1.f;
 		fade_volume			+=	dt*10.f*fade_scale;
+		//LostAlphaRus out
+	 
+		//v2v3v4 in
+		if (dist > p_source.max_distance)
+			volume_att -= 0.1f;
+		//v2v3v4 out
 
 		// Update occlusion
 		float occ			= (owner_data->g_type==SOUND_TYPE_WORLD_AMBIENT)?1.0f:SoundRender->get_occlusion	(p_source.position,.2f,occluder);
@@ -243,7 +257,9 @@ BOOL CSoundRender_Emitter::update_culling(float dt)
 	}
 	clamp				(fade_volume,0.f,1.f);
 	// Update smoothing
-	smooth_volume		= .9f*smooth_volume + .1f*(p_source.base_volume*p_source.volume*(owner_data->s_type==st_Effect?psSoundVEffects*psSoundVFactor:psSoundVMusic)*occluder_volume*fade_volume);
+	//LostAlphaRus in
+	smooth_volume = (p_source.base_volume * volume_att * (owner_data->s_type == st_Effect ? psSoundVEffects * psSoundVFactor : psSoundVMusic) * occluder_volume * fade_volume);
+	//LostAlphaRus out
 	if (smooth_volume<psSoundCull)							return FALSE;	// allow volume to go up
 	// Here we has enought "PRIORITY" to be soundable
 	// If we are playing already, return OK
@@ -254,9 +270,16 @@ BOOL CSoundRender_Emitter::update_culling(float dt)
 
 float CSoundRender_Emitter::priority()
 {
-	float	dist		= SoundRender->listener_position().distance_to	(p_source.position);
-	float	att			= p_source.min_distance/(psSoundRolloff*dist);	clamp(att,0.f,1.f);
-	return	smooth_volume*att*priority_scale;
+	//LostAlphaRus in
+	float min_max = 1.f;
+	float volume_att = 1.f;
+	float dist = SoundRender->listener_position().distance_to(p_source.position);
+
+	min_max = p_source.max_distance - p_source.min_distance;
+	volume_att = (p_source.max_distance - dist) / min_max;
+	clamp(volume_att, 0.f, p_source.volume);
+	return	smooth_volume* volume_att *priority_scale;
+	//LostAlphaRus out
 }
 
 void CSoundRender_Emitter::update_environment(float dt)

--- a/src/xrSound/SoundRender_Emitter_FSM.cpp
+++ b/src/xrSound/SoundRender_Emitter_FSM.cpp
@@ -221,7 +221,11 @@ IC void	volume_lerp(float& c, float t, float s, float dt)
 
 BOOL CSoundRender_Emitter::update_culling(float dt)
 {
-	
+	//LostAlphaRus in
+	float min_max = 1.f;
+	float volume_att = 1.f;
+	//LostAlphaRus out
+
 	if (b2D)
 	{
 		occluder_volume		= 1.f;
@@ -232,9 +236,19 @@ BOOL CSoundRender_Emitter::update_culling(float dt)
 		if (dist>p_source.max_distance)										{ smooth_volume = 0; return FALSE; }
 
 		// Calc attenuated volume
-		float att			= p_source.min_distance/(psSoundRolloff*dist);	clamp(att,0.f,1.f);
-		float fade_scale	= bStopping||(att*p_source.base_volume*p_source.volume*(owner_data->s_type==st_Effect?psSoundVEffects*psSoundVFactor:psSoundVMusic)<psSoundCull)?-1.f:1.f;
+		//LostAlphaRus in
+		min_max = p_source.max_distance - p_source.min_distance;
+		volume_att = (p_source.max_distance - dist) / min_max;
+		clamp(volume_att, 0.f, p_source.volume);
+
+		float fade_scale	= bStopping||(p_source.base_volume*p_source.volume*(owner_data->s_type==st_Effect?psSoundVEffects*psSoundVFactor:psSoundVMusic)<psSoundCull)?-1.f:1.f;
 		fade_volume			+=	dt*10.f*fade_scale;
+		//LostAlphaRus out
+	 
+		//v2v3v4 in
+		if (dist > p_source.max_distance)
+			volume_att -= 0.1f;
+		//v2v3v4 out
 
 		// Update occlusion
 		float occ			= (owner_data->g_type==SOUND_TYPE_WORLD_AMBIENT)?1.0f:SoundRender->get_occlusion	(p_source.position,.2f,occluder);
@@ -243,7 +257,9 @@ BOOL CSoundRender_Emitter::update_culling(float dt)
 	}
 	clamp				(fade_volume,0.f,1.f);
 	// Update smoothing
-	smooth_volume		= .9f*smooth_volume + .1f*(p_source.base_volume*p_source.volume*(owner_data->s_type==st_Effect?psSoundVEffects*psSoundVFactor:psSoundVMusic)*occluder_volume*fade_volume);
+	//LostAlphaRus in
+	smooth_volume = (p_source.base_volume * volume_att * (owner_data->s_type == st_Effect ? psSoundVEffects * psSoundVFactor : psSoundVMusic) * occluder_volume * fade_volume);
+	//LostAlphaRus out
 	if (smooth_volume<psSoundCull)							return FALSE;	// allow volume to go up
 	// Here we has enought "PRIORITY" to be soundable
 	// If we are playing already, return OK
@@ -254,9 +270,7 @@ BOOL CSoundRender_Emitter::update_culling(float dt)
 
 float CSoundRender_Emitter::priority()
 {
-	float	dist		= SoundRender->listener_position().distance_to	(p_source.position);
-	float	att			= p_source.min_distance/(psSoundRolloff*dist);	clamp(att,0.f,1.f);
-	return	smooth_volume*att*priority_scale;
+	return	smooth_volume*priority_scale;
 }
 
 void CSoundRender_Emitter::update_environment(float dt)

--- a/src/xrSound/SoundRender_Emitter_FSM.cpp
+++ b/src/xrSound/SoundRender_Emitter_FSM.cpp
@@ -221,6 +221,10 @@ IC void	volume_lerp(float& c, float t, float s, float dt)
 
 BOOL CSoundRender_Emitter::update_culling(float dt)
 {
+	//LostAlphaRus in
+	float min_max = 1.f;
+	float volume_att = 1.f;
+	//LostAlphaRus out
 	
 	if (b2D)
 	{
@@ -232,6 +236,11 @@ BOOL CSoundRender_Emitter::update_culling(float dt)
 		if (dist>p_source.max_distance)										{ smooth_volume = 0; return FALSE; }
 
 		// Calc attenuated volume
+		//LostAlphaRus in
+		min_max = p_source.max_distance - p_source.min_distance;
+		volume_att = (p_source.max_distance - dist) / min_max;
+		clamp(volume_att, 0.f, p_source.volume);
+		//LostAlphaRus out
 		float att			= p_source.min_distance/(psSoundRolloff*dist);	clamp(att,0.f,1.f);
 		float fade_scale	= bStopping||(att*p_source.base_volume*p_source.volume*(owner_data->s_type==st_Effect?psSoundVEffects*psSoundVFactor:psSoundVMusic)<psSoundCull)?-1.f:1.f;
 		fade_volume			+=	dt*10.f*fade_scale;
@@ -243,7 +252,9 @@ BOOL CSoundRender_Emitter::update_culling(float dt)
 	}
 	clamp				(fade_volume,0.f,1.f);
 	// Update smoothing
-	smooth_volume		= .9f*smooth_volume + .1f*(p_source.base_volume*p_source.volume*(owner_data->s_type==st_Effect?psSoundVEffects*psSoundVFactor:psSoundVMusic)*occluder_volume*fade_volume);
+	//LostAlphaRus in
+	smooth_volume = (p_source.base_volume * volume_att * (owner_data->s_type == st_Effect ? psSoundVEffects * psSoundVFactor : psSoundVMusic) * occluder_volume * fade_volume);
+	//LostAlphaRus out
 	if (smooth_volume<psSoundCull)							return FALSE;	// allow volume to go up
 	// Here we has enought "PRIORITY" to be soundable
 	// If we are playing already, return OK
@@ -254,9 +265,7 @@ BOOL CSoundRender_Emitter::update_culling(float dt)
 
 float CSoundRender_Emitter::priority()
 {
-	float	dist		= SoundRender->listener_position().distance_to	(p_source.position);
-	float	att			= p_source.min_distance/(psSoundRolloff*dist);	clamp(att,0.f,1.f);
-	return	smooth_volume*att*priority_scale;
+	return	smooth_volume*priority_scale;
 }
 
 void CSoundRender_Emitter::update_environment(float dt)

--- a/src/xrSound/SoundRender_Emitter_FSM.cpp
+++ b/src/xrSound/SoundRender_Emitter_FSM.cpp
@@ -221,10 +221,6 @@ IC void	volume_lerp(float& c, float t, float s, float dt)
 
 BOOL CSoundRender_Emitter::update_culling(float dt)
 {
-	//LostAlphaRus in
-	float min_max = 1.f;
-	float volume_att = 1.f;
-	//LostAlphaRus out
 	
 	if (b2D)
 	{
@@ -236,11 +232,6 @@ BOOL CSoundRender_Emitter::update_culling(float dt)
 		if (dist>p_source.max_distance)										{ smooth_volume = 0; return FALSE; }
 
 		// Calc attenuated volume
-		//LostAlphaRus in
-		min_max = p_source.max_distance - p_source.min_distance;
-		volume_att = (p_source.max_distance - dist) / min_max;
-		clamp(volume_att, 0.f, p_source.volume);
-		//LostAlphaRus out
 		float att			= p_source.min_distance/(psSoundRolloff*dist);	clamp(att,0.f,1.f);
 		float fade_scale	= bStopping||(att*p_source.base_volume*p_source.volume*(owner_data->s_type==st_Effect?psSoundVEffects*psSoundVFactor:psSoundVMusic)<psSoundCull)?-1.f:1.f;
 		fade_volume			+=	dt*10.f*fade_scale;
@@ -252,9 +243,7 @@ BOOL CSoundRender_Emitter::update_culling(float dt)
 	}
 	clamp				(fade_volume,0.f,1.f);
 	// Update smoothing
-	//LostAlphaRus in
-	smooth_volume = (p_source.base_volume * volume_att * (owner_data->s_type == st_Effect ? psSoundVEffects * psSoundVFactor : psSoundVMusic) * occluder_volume * fade_volume);
-	//LostAlphaRus out
+	smooth_volume		= .9f*smooth_volume + .1f*(p_source.base_volume*p_source.volume*(owner_data->s_type==st_Effect?psSoundVEffects*psSoundVFactor:psSoundVMusic)*occluder_volume*fade_volume);
 	if (smooth_volume<psSoundCull)							return FALSE;	// allow volume to go up
 	// Here we has enought "PRIORITY" to be soundable
 	// If we are playing already, return OK
@@ -265,7 +254,9 @@ BOOL CSoundRender_Emitter::update_culling(float dt)
 
 float CSoundRender_Emitter::priority()
 {
-	return	smooth_volume*priority_scale;
+	float	dist		= SoundRender->listener_position().distance_to	(p_source.position);
+	float	att			= p_source.min_distance/(psSoundRolloff*dist);	clamp(att,0.f,1.f);
+	return	smooth_volume*att*priority_scale;
 }
 
 void CSoundRender_Emitter::update_environment(float dt)


### PR DESCRIPTION
Плавная громкость при подходе к источнику звука

(Пока тестил, узнал что источник звука у актора, а именно оружие(достать предмет) динамический. При беге звук запускается по координатам актора и можно услышать как он отстает. Нужно запускать так, чтобы звук был привязан стабильно по одним координатам. Или запускать их по другому способу(как b2d)

Также у шагов фиксированная дистанция проигрывания(по поему в 25м), дальше просто звук обрезается