### PR TITLE
extend on_take event for callback system

### DIFF
--- a/src/xrGame/Inventory.cpp
+++ b/src/xrGame/Inventory.cpp
@@ -241,6 +241,8 @@ bool CInventory::DropItem(CGameObject *pObj, bool just_before_destroy, bool dont
 	VERIFY								(pIItem->m_pInventory);
 	VERIFY								(pIItem->m_pInventory==this);
 	VERIFY								(pIItem->m_ItemCurrPlace.type!=eItemPlaceUndefined);
+
+	pIItem->m_last_dropped_owner_id = pIItem->parent_id();
 	
 	pIItem->object().processing_activate(); 
 	

--- a/src/xrGame/InventoryOwner.cpp
+++ b/src/xrGame/InventoryOwner.cpp
@@ -357,7 +357,8 @@ void CInventoryOwner::OnItemTake			(CInventoryItem *inventory_item)
 {
 	CGameObject	*object = cast_game_object();
 	VERIFY		(object);
-	object->callback(GameObject::eOnItemTake)(inventory_item->object().lua_game_object());
+	object->callback(GameObject::eOnItemTake)(inventory_item->object().lua_game_object(), inventory_item->m_last_dropped_owner_id);
+	inventory_item->m_last_dropped_owner_id = 65535;
 
 	attach		(inventory_item);
 

--- a/src/xrGame/inventory_item.h
+++ b/src/xrGame/inventory_item.h
@@ -173,6 +173,7 @@ public:
 	Fvector2					m_custom_text_offset;
 	CGameFont*					m_custom_text_font;
 	u32							m_custom_text_clr_inv;
+	u32							m_last_dropped_owner_id = 65535;
 //	u32							m_custom_text_clr_hud; // used for pick_up_item on CUICellItem class
 	bool						m_custom_mark;
 	shared_str					m_custom_mark_texture;


### PR DESCRIPTION
### Proposed changes / Предлагаемые изменения
extend on_take event for callback system (non conflicted)

расширен функционал ванильного коллбека поднятия предмета для регистрации взятия с земли и выявления предыдущего владельца - из за переделанной механики работы с предметами в IXR теряется parent_id предмета в момент переноса при взятии со стеша или трупа - поэтому был добавлен этот обходной вариант

// пример использования, имплементировать не обязательно - конфликтов быть не должно если будет упущен второй аргумент метода коллбека при регистрации
```
function actor_binder:on_item_take(obj, m_last_dropped_owner_id)
        if db.actor then
	        local is_take_from_ground = (m_last_dropped_owner_id == 65535 or m_last_dropped_owner_id == db.actor:id())
	        local before_transfer_parent_id = nil
	        
	        if not is_take_from_ground then
		        before_transfer_parent_id = m_last_dropped_owner_id
	        end
	        
	        --// before_transfer_parent_id - ид последнего владельца предмета npc/mob/invbox
	        --// is_take_from_ground - взят ли предмет с земли
	        SendScriptCallback("actor_on_item_take", obj, before_transfer_parent_id, is_take_from_ground)
	        
	        if is_take_from_ground then
		        SendScriptCallback("actor_on_item_take_from_ground", obj)
	        end
        end
        -- .... other strings
end
```