### PR TITLE
#add pure call events on save created and new game present for IXR RE…

### DIFF
--- a/gamedata/scripts/alife_storage_manager.script
+++ b/gamedata/scripts/alife_storage_manager.script
@@ -115,6 +115,28 @@ function CALifeStorageManager_before_save(fname)
 end 
 
 -- called from engine!
+function CALifeStorageManager_after_save(fname)
+	if ffx_path_utils then
+		fname = ffx_path_utils.get_file_name(fname, false)
+	end
+	
+	local _path = getFS():update_path('$game_saves$', '')
+	
+	SendScriptCallback("save_file_created", _path, fname)
+end
+
+-- called from engine!
+function CALifeStorageManager_new_game(fname)
+	if ffx_path_utils then
+		fname = ffx_path_utils.get_file_name(fname, false)
+	end
+	
+	local _path = getFS():update_path('$game_saves$', '')
+	
+	SendScriptCallback("new_game_created", _path, fname)
+end
+
+-- called from engine!
 function CALifeStorageManager_save(fname)
 	--printf("CALifeStorageManager_save START FINISHED")
 end 
@@ -150,6 +172,12 @@ function CALifeStorageManager_load(fname)
 	--alun_utils.print_table(m_data,"m_data_on_load ("..path..")")
 
 	SendScriptCallback("load_state",m_data)
+	
+	if ffx_path_utils then
+		fname = ffx_path_utils.get_file_name(fname, false)
+	end
+	local _path = getFS():update_path('$game_saves$', '')
+	SendScriptCallback("save_file_loaded", _path, fname)
 	
 	--alun_utils.debug_write(strformat("CALifeStorageManager_load END"))
 end

--- a/src/xrGame/alife_storage_manager.cpp
+++ b/src/xrGame/alife_storage_manager.cpp
@@ -105,6 +105,13 @@ void CALifeStorageManager::save(LPCSTR save_name_no_check, bool update_name)
 		funct2((LPCSTR)m_save_name);
 	}
 
+	// To get the savegame fname to make our own custom save states
+	luabind::functor<void> funct3;
+	if (ai().script_engine().functor("alife_storage_manager.CALifeStorageManager_after_save", funct3))
+	{
+		funct3((LPCSTR)m_save_name);
+	}
+
 	if (!update_name)
 		xr_strcpy					(m_save_name,saveBackup);
 }

--- a/src/xrGame/alife_update_manager.cpp
+++ b/src/xrGame/alife_update_manager.cpp
@@ -291,6 +291,12 @@ void CALifeUpdateManager::new_game			(LPCSTR save_name)
 #endif // #ifdef DEBUG
 
 	Msg									("* New game is successfully created!");
+
+	luabind::functor<void> funct;
+	if (ai().script_engine().functor("alife_storage_manager.CALifeStorageManager_new_game", funct))
+	{
+		funct((LPCSTR)save_name);
+	}
 }
 
 void CALifeUpdateManager::load			(LPCSTR game_name, bool no_assert, bool new_only)


### PR DESCRIPTION
Добавлены прямые вызовы в скрипт на событиях создания сохранений и создании новой игры - для будущей правки по добавлению ixr_reactive_storage использующего маршлизацию для сохранения изолированных хранилищ для скриптовых данных независимо от сохранений игры. 