### PR TITLE
Develop higlight related item sections by cfg options

### DIFF
--- a/src/xrGame/inventory_item.cpp
+++ b/src/xrGame/inventory_item.cpp
@@ -107,6 +107,21 @@ void CInventoryItem::Load(LPCSTR section)
 {
 	CHitImmunity::LoadImmunities	(pSettings->r_string(section,"immunities_sect"),pSettings);
 
+	// FFx0001 ++ begin
+	// Highlight separated by delimeter ',' related item sections on mouseover from the actor's inventory
+	m_HiglightRelatedItemSections.clear();
+	if (pSettings->line_exist(section, "highlight_related_sections"))
+	{
+		LPCSTR separated_sections = pSettings->r_string(section, "highlight_related_sections");
+		for (int it = 0, count = _GetItemCount(separated_sections); it < count; ++it)
+		{
+			string128 higlight_section;
+			_GetItem(separated_sections, it, higlight_section);
+			m_HiglightRelatedItemSections.push_back(higlight_section);
+		}
+	}
+	// FFx0001 ++ end
+
 	if (cast_game_object())
 	{
 		cast_game_object()->SpatialComponent->spatial.type |= STYPE_VISIBLEFORAI;

--- a/src/xrGame/inventory_item.h
+++ b/src/xrGame/inventory_item.h
@@ -182,7 +182,7 @@ public:
 	LPCSTR						m_custom_mark_lanim;
 
 	SInvItemPlace				m_ItemCurrPlace;
-
+	xr_vector<shared_str>		m_HiglightRelatedItemSections; // FFx0001 ++
 
 	virtual void				OnMoveToSlot		(const SInvItemPlace& prev) {};
 	virtual void				OnMoveToBelt		(const SInvItemPlace& prev) {};

--- a/src/xrGame/ui/UIActorMenu.cpp
+++ b/src/xrGame/ui/UIActorMenu.cpp
@@ -678,6 +678,40 @@ void CUIActorMenu::highlight_armament( PIItem item, CUIDragDropListEx* ddlist )
 	highlight_ammo_for_weapon( item, ddlist );
 	highlight_weapons_for_ammo( item, ddlist );
 	highlight_weapons_for_addon( item, ddlist );
+	highlight_related_config_sections(item, ddlist); // FFx001 ++
+}
+
+// FFx0001 ++
+// Highlight separated by delimeter ',' related item sections on mouseover from the actor's inventory is item config include line highlight_related_sections with separated sections
+void CUIActorMenu::highlight_related_config_sections(PIItem item, CUIDragDropListEx* ddlist)
+{
+	VERIFY(item);
+	VERIFY(ddlist);
+
+	if (item->m_HiglightRelatedItemSections.size() > 0)
+	{
+		u32 const cnt = ddlist->ItemsCount();
+		for (size_t j = 0; j < item->m_HiglightRelatedItemSections.size(); ++j)
+		{
+			for (u32 i = 0; i < cnt; ++i)
+			{
+				CUICellItem* ci = ddlist->GetItemIdx(i);
+				PIItem _item = (PIItem)ci->m_pData;
+				if (!_item)
+				{
+					continue;
+				}
+
+				const shared_str item_section = _item->object().cNameSect();
+				const shared_str to_higlight_section = item->m_HiglightRelatedItemSections[j];
+
+				if (item_section.c_str() != nullptr && to_higlight_section.c_str() != nullptr && xr_strcmp(to_higlight_section, item_section) == 0)
+				{
+					ci->m_select_armament = true;
+				}
+			}
+		}
+	}
 }
 
 void CUIActorMenu::highlight_ammo_for_weapon(PIItem weapon_item, CUIDragDropListEx* ddlist)

--- a/src/xrGame/ui/UIActorMenu.h
+++ b/src/xrGame/ui/UIActorMenu.h
@@ -240,6 +240,7 @@ private:
 	void						highlight_weapons_for_ammo	(PIItem ammo_item, CUIDragDropListEx* ddlist);
 	bool						highlight_addons_for_weapon	(PIItem weapon_item, CUICellItem* ci);
 	void						highlight_weapons_for_addon	(PIItem addon_item, CUIDragDropListEx* ddlist);
+	void						highlight_related_config_sections (PIItem item, CUIDragDropListEx* ddlist); // FFx001 ++
 
 protected:			
 	void						Construct					();


### PR DESCRIPTION
### Proposed changes / Предлагаемые изменения
Highlight separated by delimeter ',' related item sections on mouseover from the actor's inventory is item config include line highlight_related_sections with separated sections

ADD any item config parameter "highlight_related_sections"  use as highlight_related_sections = section OR highlight_related_sections  = section, section,...  

;--------------------------------------
; Родительский предмет с настроенной подсветкой дочерних предметов
;--------------------------------------
[root_item_section]:identity_immunities
highlight_related_sections = related_section_a, related_section_b; секции предметов которые будут подсвечены как зависимые от этого предмета

;--------------------------------------
; Данные предметы будут подсвечены если навести на root_item_section предмет в инвентаре
;--------------------------------------
[related_section_a]:identity_immunities
highlight_related_sections = root_item_section; можно добавить обратную подсветку родительского предмета при наведении на дочерний если требуется

[related_section_b]:identity_immunities
highlight_related_sections =  root_item_section; можно добавить обратную подсветку родительского предмета при наведении на дочерний если требуется


### Testing / Тестирование
- [x] Manual testing success