### PR TITLE
Add pure inv box callbacks take place

### DIFF
--- a/gamedata/configs/game_global.ltx
+++ b/gamedata/configs/game_global.ltx
@@ -27,6 +27,8 @@ OnSkipKillActor = xr_effects.enable_ui
 
 ; Call of Chernobyl
 ;OnCanTake = _G.CInventoryBox_CanTake
+;OnInvBoxCanTakeItem = _G.CInventoryBox_OnInvBoxCanTakeItem
+;OnInvBoxCanPlaceItem = _G.CInventoryBox_OnInvBoxCanPlaceItem
 ;OnBeforeHit = _G.CActor__BeforeHitCallback
 ;OnUnregister = _G.CSE_ALifeDynamicObject_on_unregister
 ;OnInventoryEat = _G.CInventory__eat

--- a/gamedata_cs/configs/game_global.ltx
+++ b/gamedata_cs/configs/game_global.ltx
@@ -24,6 +24,8 @@ OnStartAttack = sim_combat.start_attack
 
 ; Call of Chernobyl
 ;OnCanTake = _G.CInventoryBox_CanTake
+;OnInvBoxCanTakeItem = _G.CInventoryBox_OnInvBoxCanTakeItem
+;OnInvBoxCanPlaceItem = _G.CInventoryBox_OnInvBoxCanPlaceItem
 ;OnBeforeHit = _G.CActor__BeforeHitCallback
 ;OnUnregister = _G.CSE_ALifeDynamicObject_on_unregister
 ;OnInventoryEat = _G.CInventory__eat

--- a/src/xrGame/ui/UIActorMenu.h
+++ b/src/xrGame/ui/UIActorMenu.h
@@ -194,6 +194,12 @@ private:
 	const char* m_onCanTake = {};
 	bool m_isCanTake = false;
 
+	const char* m_onInvBoxCanTakeItem = {};	// FFx0001
+	bool m_isInvBoxCanTakeItem = false;		// FFx0001
+
+	const char* m_onInvBoxCanPlaceItem = {};	// FFx0001
+	bool m_isInvBoxCanPlaceItem = false;		// FFx0001
+
 	const char* m_onCanDisassembleItem = {};
 	bool m_isCanDisassembleItem = false;
 
@@ -322,6 +328,8 @@ protected:
 	bool						ToPartnerTrade				(CUICellItem* itm, bool b_use_cursor_pos);
 	bool						ToPartnerTradeBag			(CUICellItem* itm, bool b_use_cursor_pos);
 	bool						ToDeadBodyBag				(CUICellItem* itm, bool b_use_cursor_pos);
+	bool						IsAllowTakeFromInvBox		(CUICellItem* itm); // FFx0001
+	bool						IsAllowPlaceToInvBox		(CUICellItem* itm); // FFx0001
 
 	void						AttachAddon					(PIItem item_to_upgrade);
 	void						DetachAddon					(LPCSTR addon_name, PIItem itm = NULL);

--- a/src/xrGame/ui/UIActorMenuDeadBodySearch.cpp
+++ b/src/xrGame/ui/UIActorMenuDeadBodySearch.cpp
@@ -142,6 +142,55 @@ void CUIActorMenu::DeInitDeadBodySearchMode()
 	}
 }
 
+// FFx0001 
+bool CUIActorMenu::IsAllowTakeFromInvBox(CUICellItem* itm)
+{
+	if (!m_isInvBoxCanTakeItem) {
+		return true;
+	}
+
+	// inv box
+	if (m_pInvBox) {
+		luabind::functor<bool> funct;
+		R_ASSERT2(ai().script_engine().functor(m_onInvBoxCanTakeItem, funct), make_string<const char*>("failed to get %s functor", m_onInvBoxCanTakeItem));
+
+		if (funct(m_pInvBox->cast_game_object()->lua_game_object(), ((PIItem)itm->m_pData)->cast_game_object()->lua_game_object()) == false)
+		{
+			return false;
+		}
+	}
+	else {
+		// npc
+	}
+
+	return true;
+}
+
+// FFx0001
+bool CUIActorMenu::IsAllowPlaceToInvBox(CUICellItem* itm)
+{
+	if (!m_isInvBoxCanPlaceItem) {
+		return true;
+	}
+
+	// inv box
+	if (m_pInvBox) {
+		luabind::functor<bool> funct;
+		R_ASSERT2(ai().script_engine().functor(m_onInvBoxCanPlaceItem, funct), make_string<const char*>("failed to get %s functor", m_onInvBoxCanPlaceItem));
+
+		if (funct(m_pInvBox->cast_game_object()->lua_game_object(), ((PIItem)itm->m_pData)->cast_game_object()->lua_game_object()) == false)
+		{
+			return false;
+		}
+	}
+	else {
+		// npc
+	}
+
+	return true;
+}
+
+
 bool CUIActorMenu::ToDeadBodyBag(CUICellItem* itm, bool b_use_cursor_pos)
 {
 	PIItem quest_item = (PIItem)itm->m_pData;
@@ -184,6 +233,11 @@ bool CUIActorMenu::ToDeadBodyBag(CUICellItem* itm, bool b_use_cursor_pos)
 			{
 				return false;
 			}
+
+		}
+
+		if (!IsAllowPlaceToInvBox(itm)) {
+			return false;
 		}
 	}
 
@@ -272,26 +326,39 @@ void CUIActorMenu::TakeAllFromPartner(CUIWindow* w, void* d)
 		}
 		PIItem item = (PIItem)(ci->m_pData);
 		move_item_check( item, m_pPartnerInvOwner, m_pActorInvOwner, false );
-	}//for i
-	m_pDeadBodyBagList->ClearAll( true ); // false
+	}
+
+	m_pDeadBodyBagList->ClearAll(true); // false
 }
 
 void CUIActorMenu::TakeAllFromInventoryBox()
 {
 	u16 actor_id = m_pActorInvOwner->object_id();
+	xr_vector<u16> IgnoredItemsIds = {};
 
 	u32 const cnt = m_pDeadBodyBagList->ItemsCount();
 	for ( u32 i = 0; i < cnt; ++i )
 	{
 		CUICellItem* ci = m_pDeadBodyBagList->GetItemIdx(i);
+		PIItem item = (PIItem)(ci->m_pData);
+
+		// FFx0001
+		if (!IsAllowTakeFromInvBox(ci)) { 
+			IgnoredItemsIds.push_back(item->object_id());
+
+			continue;
+		}
+
 		for ( u32 j = 0; j < ci->ChildsCount(); ++j )
 		{
 			PIItem j_item = (PIItem)(ci->Child(j)->m_pData);
 			move_item_from_to( m_pInvBox->ID(), actor_id, j_item->object_id() );
 		}
 
-		PIItem item = (PIItem)(ci->m_pData);
+		
 		move_item_from_to( m_pInvBox->ID(), actor_id, item->object_id() );
-	}//for i
-	m_pDeadBodyBagList->ClearAll( true ); // false
+	}
+
+	m_pDeadBodyBagList->ClearAll(true, IgnoredItemsIds); // FFx0001
+	IgnoredItemsIds.clear();
 }

--- a/src/xrGame/ui/UIActorMenuInitialize.cpp
+++ b/src/xrGame/ui/UIActorMenuInitialize.cpp
@@ -39,6 +39,9 @@ CUIActorMenu::CUIActorMenu()
 	LoadCallbackGlobals(m_isEffectDisassemble, m_onEffectDisassemble, "OnEffectDisassemble");
 	LoadCallbackGlobals(m_isDonateCurrentItem, m_onDonateCurrentItem, "OnDonateCurrentItem");
 
+	LoadCallbackGlobals(m_isInvBoxCanTakeItem, m_onInvBoxCanTakeItem, "OnInvBoxCanTakeItem");		// FFx0001
+	LoadCallbackGlobals(m_isInvBoxCanPlaceItem, m_onInvBoxCanPlaceItem, "OnInvBoxCanPlaceItem");	// FFx0001
+
 	Construct						();
 }
 

--- a/src/xrGame/ui/UIActorMenuInventory.cpp
+++ b/src/xrGame/ui/UIActorMenuInventory.cpp
@@ -673,6 +673,11 @@ bool CUIActorMenu::ToSlot(CUICellItem* itm, bool force_place, u16 slot_id)
 
 bool CUIActorMenu::ToBag(CUICellItem* itm, bool b_use_cursor_pos)
 {
+	// FFx0001
+	if (!IsAllowTakeFromInvBox(itm)) {
+		return false;
+	}
+
 	PIItem	iitem						= (PIItem)itm->m_pData;
 
 	bool b_own_item						= (iitem->parent_id()==m_pActorInvOwner->object_id());
@@ -1445,15 +1450,20 @@ void CUIActorMenu::ProcessPropertiesBoxClicked(CUIWindow* w, void* d)
 				if(item->parent_id() == m_pActorInvOwner->object_id()) {
 					auto ownerID = m_pPartnerInvOwner ? m_pPartnerInvOwner->object_id() : m_pInvBox->ID();
 
-					if(d_ == (void*)33) {
-						for(u32 i = 0; i < cell_item->ChildsCount(); ++i) {
-							CUICellItem* child_itm = cell_item->Child(i);
-							PIItem child_iitm = (PIItem)(child_itm->m_pData);
-							move_item_from_to(item->parent_id(), ownerID, child_iitm->object_id());
+					if (IsAllowPlaceToInvBox(cell_item)) {
+						if(d_ == (void*)33) {
+							for(u32 i = 0; i < cell_item->ChildsCount(); ++i) {
+								CUICellItem* child_itm = cell_item->Child(i);
+								PIItem child_iitm = (PIItem)(child_itm->m_pData);
+								if (IsAllowPlaceToInvBox(cell_item)) {
+									move_item_from_to(item->parent_id(), ownerID, child_iitm->object_id());
+								}
+							}
+						}
+						if (IsAllowPlaceToInvBox(cell_item)) {
+							move_item_from_to(item->parent_id(), ownerID, item->object_id());
 						}
 					}
-
-					move_item_from_to(item->parent_id(), ownerID, item->object_id());
 				}
 				else {
 					auto ownerID = m_pPartnerInvOwner ? m_pPartnerInvOwner->object_id() : m_pInvBox->ID();

--- a/src/xrGame/ui/UIActorMenuInventory.cpp
+++ b/src/xrGame/ui/UIActorMenuInventory.cpp
@@ -1450,20 +1450,21 @@ void CUIActorMenu::ProcessPropertiesBoxClicked(CUIWindow* w, void* d)
 				if(item->parent_id() == m_pActorInvOwner->object_id()) {
 					auto ownerID = m_pPartnerInvOwner ? m_pPartnerInvOwner->object_id() : m_pInvBox->ID();
 
-					if (IsAllowPlaceToInvBox(cell_item)) {
-						if(d_ == (void*)33) {
-							for(u32 i = 0; i < cell_item->ChildsCount(); ++i) {
-								CUICellItem* child_itm = cell_item->Child(i);
-								PIItem child_iitm = (PIItem)(child_itm->m_pData);
-								if (IsAllowPlaceToInvBox(cell_item)) {
-									move_item_from_to(item->parent_id(), ownerID, child_iitm->object_id());
-								}
+					if(d_ == (void*)33 && IsAllowPlaceToInvBox(cell_item)) {
+						for(u32 i = 0; i < cell_item->ChildsCount(); ++i) {
+							CUICellItem* child_itm = cell_item->Child(i);
+							PIItem child_iitm = (PIItem)(child_itm->m_pData);
+
+							if (IsAllowPlaceToInvBox(cell_item)) {
+								move_item_from_to(item->parent_id(), ownerID, child_iitm->object_id());
 							}
 						}
-						if (IsAllowPlaceToInvBox(cell_item)) {
-							move_item_from_to(item->parent_id(), ownerID, item->object_id());
-						}
 					}
+
+					if (IsAllowPlaceToInvBox(cell_item)) {
+						move_item_from_to(item->parent_id(), ownerID, item->object_id());
+					}
+					
 				}
 				else {
 					auto ownerID = m_pPartnerInvOwner ? m_pPartnerInvOwner->object_id() : m_pInvBox->ID();

--- a/src/xrGame/ui/UIActorMenuInventory.cpp
+++ b/src/xrGame/ui/UIActorMenuInventory.cpp
@@ -1449,22 +1449,20 @@ void CUIActorMenu::ProcessPropertiesBoxClicked(CUIWindow* w, void* d)
 			else {
 				if(item->parent_id() == m_pActorInvOwner->object_id()) {
 					auto ownerID = m_pPartnerInvOwner ? m_pPartnerInvOwner->object_id() : m_pInvBox->ID();
+					bool isAllowPlace = IsAllowPlaceToInvBox(cell_item);
 
-					if(d_ == (void*)33 && IsAllowPlaceToInvBox(cell_item)) {
+					if(d_ == (void*)33 && isAllowPlace) {
 						for(u32 i = 0; i < cell_item->ChildsCount(); ++i) {
 							CUICellItem* child_itm = cell_item->Child(i);
 							PIItem child_iitm = (PIItem)(child_itm->m_pData);
 
-							if (IsAllowPlaceToInvBox(cell_item)) {
-								move_item_from_to(item->parent_id(), ownerID, child_iitm->object_id());
-							}
+							move_item_from_to(item->parent_id(), ownerID, child_iitm->object_id());
 						}
 					}
 
-					if (IsAllowPlaceToInvBox(cell_item)) {
+					if (isAllowPlace) {
 						move_item_from_to(item->parent_id(), ownerID, item->object_id());
 					}
-					
 				}
 				else {
 					auto ownerID = m_pPartnerInvOwner ? m_pPartnerInvOwner->object_id() : m_pInvBox->ID();

--- a/src/xrGame/ui/UIActorMenu_action.cpp
+++ b/src/xrGame/ui/UIActorMenu_action.cpp
@@ -235,10 +235,19 @@ bool CUIActorMenu::OnItemDbClick(CUICellItem* itm)
 	{
 	case iActorSlot:
 		{
-			if ( m_currMenuMode == mmDeadBodySearch )
-				ToDeadBodyBag	( itm, false );
-			else
-				ToBag			( itm, false );
+			if (m_currMenuMode == mmDeadBodySearch) {
+				// FFx0001
+				if (IsAllowPlaceToInvBox(itm)) {
+					ToDeadBodyBag(itm, false);
+				}
+			}
+			else 
+			{
+				// FFx0001
+				if (IsAllowTakeFromInvBox(itm)) {
+					ToBag(itm, false);
+				}
+			}
 			break;
 		}
 	case iActorBag:

--- a/src/xrGame/ui/UIDragDropListEx.cpp
+++ b/src/xrGame/ui/UIDragDropListEx.cpp
@@ -294,10 +294,11 @@ void CUIDragDropListEx::GetClientArea(Frect& r)
 		r.x2 -= m_vScrollBar->GetWidth	();
 }
 
-void CUIDragDropListEx::ClearAll(bool bDestroy)
+// FFx0001
+void CUIDragDropListEx::ClearAll(bool bDestroy, xr_vector<u16> IgnoredItemsIds)
 {
 	DestroyDragItem			();
-	m_container->ClearAll	(bDestroy);
+	m_container->ClearAll	(bDestroy, IgnoredItemsIds); // FFx0001
 	m_selected_item			= nullptr;
 	m_container->SetWndPos	(Fvector2().set(0,0));
 	ResetCellsCapacity		();
@@ -843,40 +844,94 @@ bool CUICellContainer::ValidCell(const Ivector2& pos) const
 	return !(pos.x<0 || pos.y<0 || pos.x>=m_cellsCapacity.x || pos.y>=m_cellsCapacity.y);
 }
 
-void CUICellContainer::ClearAll(bool bDestroy)
+// FFx0001 add support ignore items by ids
+void CUICellContainer::ClearAll(bool bDestroy, xr_vector<u16> IgnoredItemsIds)
 {
+	bool DeepSearch = false;
+	size_t cnt = IgnoredItemsIds.size();
+
+	if (!IgnoredItemsIds.empty()) {
+		DeepSearch = true;
+	}
+
 	{
 		for (CUICell& cell : m_cells)
 		{
-			cell.Clear();
+			bool IsIgnored = false;
+			CUICellItem* ci = cell.m_item;
+			if (ci) {
+				PIItem item = (PIItem)(ci->m_pData);
+				if (item) {
+					u16 ItemId = item->object_id();
+					if (DeepSearch) {
+						for (size_t i = 0; i < cnt; i++)
+						{
+							if (IgnoredItemsIds[i] == ItemId)
+							{
+								IsIgnored = true;
+								break;
+							}
+						}
+					}
+				}
+			}
+
+			if (!IsIgnored) {
+				cell.Clear();
+			}
 		}
 	}
 
 	xrCriticalSectionGuard guard(csUi);
-	while (!m_ChildWndList.empty())
+
+	auto it = m_ChildWndList.rbegin();
+
+	while (it != m_ChildWndList.rend())
 	{
-		CUIWindow* w = m_ChildWndList.back();
+		CUIWindow* w = *it;
 		CUICellItem* wc = w != nullptr ? w->ui_cast_cell_item() : nullptr;
 		VERIFY(!wc->IsAutoDelete());
-		DetachChild(wc);
+		
+		if (!wc) {
+			++it;
+			continue;
+		}
 
-		while (wc->ChildsCount())
-		{
-			CUICellItem* ci = wc->PopChild(nullptr);
-			R_ASSERT(ci->ChildsCount() == 0);
-
-			if (bDestroy)
+		bool IsIgnored = false;
+		if (DeepSearch) {
+			u16 ItemId = ((PIItem)(wc->m_pData))->object_id();
+			for (size_t i = 0; i < cnt; i++)
 			{
-				delete_data(ci);
+				if (IgnoredItemsIds[i] == ItemId)
+				{
+					IsIgnored = true;
+					break;
+				}
 			}
 		}
 
-		if (bDestroy)
-		{
-			delete_data(wc);
-		}
-	}
+		if (!IsIgnored) {
+			DetachChild(wc);
 
+			while (wc->ChildsCount())
+			{
+				CUICellItem* ci = wc->PopChild(nullptr);
+				R_ASSERT(ci->ChildsCount() == 0);
+
+				if (bDestroy)
+				{
+					delete_data(ci);
+				}
+			}
+
+			if (bDestroy)
+			{
+				delete_data(wc);
+			}
+		}
+
+		++it;
+	}
 }
 
 Ivector2 CUICellContainer::PickCell(const Fvector2& abs_pos)

--- a/src/xrGame/ui/UIDragDropListEx.h
+++ b/src/xrGame/ui/UIDragDropListEx.h
@@ -126,7 +126,7 @@ public:
 			void			CreateDragItem		(CUICellItem* itm);
 
 			void			DestroyDragItem		();
-			void			ClearAll			(bool bDestroy);	
+			void			ClearAll(bool bDestroy, xr_vector<u16> IgnoredItemsIds = {}); // FFx0001
 			void			Compact				();
 			bool			IsOwner				(CUICellItem* itm);
 			void			clear_select_armament();
@@ -200,7 +200,7 @@ protected:
 
 				void			Grow				();
 				void			Shrink				();
-				void			ClearAll			(bool bDestroy);
+				void			ClearAll			(bool bDestroy, xr_vector<u16> IgnoredItemsIds = {}); // FFx0001
 				void			clear_select_armament();
 
 


### PR DESCRIPTION
Добавлены колбеки обратного вызова для управления доступностью брать или класть предмет в инвентарный бокс
ADD game_system.ltx
```
;OnInvBoxCanTakeItem = _G.CInventoryBox_OnInvBoxCanTakeItem
;OnInvBoxCanPlaceItem = _G.CInventoryBox_OnInvBoxCanPlaceItem
```

examples: _g.script:
```
-- called from engine!
function CInventoryBox_OnInvBoxCanTakeItem(box, item)

	local flags = { ret_value = true }

	SendScriptCallback("CInventoryBox_OnInvBoxCanTakeItem", box, item, flags)

	return flags.ret_value
end

-- called from engine!
function CInventoryBox_OnInvBoxCanPlaceItem(box, item)

	local flags = { ret_value = true }

	SendScriptCallback("CInventoryBox_OnInvBoxCanPlaceItem", box, item, flags)

	return flags.ret_value
end
```
### Testing / Тестирование
- [x] Game load
- [x] Game save
- [x] Open inventory
- [x] Open Invbox Inventory 
- [x] Open Corpse Inventory 
- [x] Open TradeWnd Inventory 
- [x] Inventory (drag drop) (drop item) (take item)
- [x] Corpse Inventory  (drag drop) (take all) (place all)
- [x] Invbox Inventory  (drag drop) (take all) (place all)
- [x] TradeWnd Inventory  (drag drop) (buy) (sell)