### PR TITLE
Расширен функционал газ маски и капель дождя

### DIFF
--- a/src/Layers/xrRenderPC_R2/r2_rendertarget_phase_screen_postprocess.cpp
+++ b/src/Layers/xrRenderPC_R2/r2_rendertarget_phase_screen_postprocess.cpp
@@ -54,6 +54,12 @@ void CRenderTarget::PhaseSaturation() {
 
 void CRenderTarget::PhaseRaindrops()
 {
+	const bool ItemCfgHudRainDropsAvialable = g_pGamePersistent->ShaderParams.ItemCfgHudRainDropsAvialable;
+	if (!ItemCfgHudRainDropsAvialable)
+	{
+		return;
+	}
+
 	const float condition = g_pGamePersistent->ShaderParams.HelmetCondition;
 	if (condition < 0)
 	{

--- a/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_screen_postprocess.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_rendertarget_phase_screen_postprocess.cpp
@@ -58,6 +58,12 @@ void CRenderTarget::PhaseSaturation()
 
 void CRenderTarget::PhaseRaindrops()
 {
+	const bool ItemCfgHudRainDropsAvialable = g_pGamePersistent->ShaderParams.ItemCfgHudRainDropsAvialable;
+	if (!ItemCfgHudRainDropsAvialable)
+	{
+		return;
+	}
+
 	const float condition = g_pGamePersistent->ShaderParams.HelmetCondition;
 	if (condition < 0)
 	{
@@ -74,6 +80,12 @@ void CRenderTarget::PhaseRaindrops()
 
 void CRenderTarget::PhaseGasmask()
 {
+	const bool ItemCfgHudGasMaskAvialable = g_pGamePersistent->ShaderParams.ItemCfgHudGasMaskAvialable;
+	if (!ItemCfgHudGasMaskAvialable)
+	{
+		return;
+	}
+
 	const float condition = g_pGamePersistent->ShaderParams.HelmetCondition;
 	if (condition < 0)
 	{

--- a/src/xrEngine/IGame_Persistent.h
+++ b/src/xrEngine/IGame_Persistent.h
@@ -53,6 +53,8 @@ public:
 	struct ShaderParamsData
 	{
 		float HelmetCondition = 0;
+		bool ItemCfgHudGasMaskAvialable = true;
+		bool ItemCfgHudRainDropsAvialable = true;
 	};
 
 	params m_game_params;

--- a/src/xrGame/Actor.cpp
+++ b/src/xrGame/Actor.cpp
@@ -1469,10 +1469,28 @@ void CActor::UpdateCL()
 		psHUD_Flags.set(HUD_DRAW_RT, true);
 
 		g_pGamePersistent->ShaderParams.HelmetCondition = -1;
+		g_pGamePersistent->ShaderParams.ItemCfgHudGasMaskAvialable = true;
+		g_pGamePersistent->ShaderParams.ItemCfgHudRainDropsAvialable = true;
 
 		if (PIItem Helmet = inventory().ItemFromSlot(HELMET_SLOT))
 		{
 			g_pGamePersistent->ShaderParams.HelmetCondition = Helmet->GetCondition();
+			CHelmet* CHM = Helmet->cast_helmet();
+
+			if (CHM) {
+				g_pGamePersistent->ShaderParams.ItemCfgHudGasMaskAvialable = CHM->bIsHudGasMaskAvialable;
+				g_pGamePersistent->ShaderParams.ItemCfgHudRainDropsAvialable = CHM->bIsHudRainDropsAvialable;
+			}
+		}
+		else if (PIItem Outfit = inventory().ItemFromSlot(OUTFIT_SLOT))
+		{
+			CCustomOutfit* COF = Outfit->cast_outfit();
+
+			if (COF && !COF->bIsHelmetAvaliable) {
+				g_pGamePersistent->ShaderParams.HelmetCondition = Outfit->GetCondition();
+				g_pGamePersistent->ShaderParams.ItemCfgHudGasMaskAvialable = COF->bIsHudGasMaskAvialable;
+				g_pGamePersistent->ShaderParams.ItemCfgHudRainDropsAvialable = COF->bIsHudRainDropsAvialable;
+			}
 		}
 	}
 

--- a/src/xrGame/ActorHelmet.cpp
+++ b/src/xrGame/ActorHelmet.cpp
@@ -54,6 +54,9 @@ void CHelmet::Load(LPCSTR section)
 	m_BonesProtectionSect			= READ_IF_EXISTS(pSettings, r_string, section, "bones_koeff_protection",  "" );
 	m_fShowNearestEnemiesDistance	= READ_IF_EXISTS(pSettings, r_float, section, "nearest_enemies_show_dist",  0.0f );
 
+	bIsHudGasMaskAvialable = !!READ_IF_EXISTS(pSettings, r_bool, section, "hud_gas_mask_avaliable", true);		// FFx0001 ++
+	bIsHudRainDropsAvialable = !!READ_IF_EXISTS(pSettings, r_bool, section, "hud_rain_drops_avaliable", true);  // FFx0001 ++
+
 	if (pSettings->line_exist(section, "glass_present"))
 	{
 		GlassPresent = pSettings->r_bool(section, "glass_present");

--- a/src/xrGame/ActorHelmet.h
+++ b/src/xrGame/ActorHelmet.h
@@ -40,6 +40,9 @@ public:
 	float					m_fPowerRestoreSpeed;
 	float					m_fBleedingRestoreSpeed;
 
+	bool					bIsHudGasMaskAvialable;		// FFx0001 ++
+	bool					bIsHudRainDropsAvialable;	// FFx0001 ++
+
 	float					m_fShowNearestEnemiesDistance;
 
 	void					ReloadBonesProtection	();

--- a/src/xrGame/CustomOutfit.cpp
+++ b/src/xrGame/CustomOutfit.cpp
@@ -113,6 +113,9 @@ void CCustomOutfit::Load(LPCSTR section)
 	m_BonesProtectionSect	= READ_IF_EXISTS(pSettings, r_string, section, "bones_koeff_protection",  "" );
 	bIsHelmetAvaliable		= !!READ_IF_EXISTS(pSettings, r_bool, section, "helmet_avaliable", true);
 
+	bIsHudGasMaskAvialable = !!READ_IF_EXISTS(pSettings, r_bool, section, "hud_gas_mask_avaliable", true);		// FFx0001 ++
+	bIsHudRainDropsAvialable = !!READ_IF_EXISTS(pSettings, r_bool, section, "hud_rain_drops_avaliable", true);  // FFx0001 ++
+
 	// Added by Axel, to enable optional condition use on any item
 	m_flags.set(FUsingCondition, READ_IF_EXISTS(pSettings, r_bool, section, "use_condition", true));
 

--- a/src/xrGame/CustomOutfit.h
+++ b/src/xrGame/CustomOutfit.h
@@ -62,6 +62,8 @@ public:
 	shared_str				m_NightVisionSect;
 
 	bool					bIsHelmetAvaliable;
+	bool					bIsHudGasMaskAvialable;		// FFx0001 ++
+	bool					bIsHudRainDropsAvialable;	// FFx0001 ++
 	bool					isDisableChangeSkin = true;
 
 	virtual u32				ef_equipment_type		() const;


### PR DESCRIPTION
Газ маска и капли дождя теперь доступны для костюмов с запрещенным слотом шлема по умолчанию если включены консольные команды:
    r_use_gasmask и r_use_rain_drops

Добавлены параметры для секции костюмов и шлемов по умолчанию true если не задать
 hud_gas_mask_avaliable = true // доступна ли отрисовка капель дождя 
 hud_rain_drops_avaliable = true // доступна ли отрисовка газ маски

### Testing / Тестирование
- [x] Manual testing / Ручное тестирование