### PR TITLE
Make NvAPI initialization more tolerant...

### DIFF
--- a/src/xrPlay/NvGPUTransferee.cpp
+++ b/src/xrPlay/NvGPUTransferee.cpp
@@ -37,27 +37,40 @@ void CNvReader::Initialize()
 			return;
 		}
 
-		auto TryToInitializeFunctionLambda = [this](void** pFuncPtr, u32 FuncId) -> bool
+		// Try to initialize functions.
+		// If `required` is true, a missing function aborts NVAPI support.
+		// If `required` is false, we log and continue but leave the pointer null so callers can fall back.
+		auto TryToInitializeFunctionLambda = [this](void** pFuncPtr, u32 FuncId, bool required = true) -> bool
 		{
 			*pFuncPtr = (*NvAPI_QueryInterface)(FuncId);
 			if (*pFuncPtr == nullptr)
 			{
-				FreeModule(hNvAPIDLL);
-				hNvAPIDLL = nullptr;
-				Msg("! Found nvapi64.dll, but DLL missing Func ID \"%u\"", FuncId);
-				return false;
+				if (required)
+				{
+					FreeModule(hNvAPIDLL);
+					hNvAPIDLL = nullptr;
+					Msg("! Found nvapi64.dll, but DLL missing Func ID \"%u\"", FuncId);
+					return false;
+				}
+				else
+				{
+					Msg("[WARN] nvapi64.dll present but missing optional Func ID \"%u\"; continuing without it", FuncId);
+					return true;
+				}
 			}
 
 			return true;
 		};
 
+		// Required essentials
 		if (!TryToInitializeFunctionLambda((void**)&NvAPI_Initialize, 0x0150E828))
 		{ return; }
 		if (!TryToInitializeFunctionLambda((void**)&NvAPI_EnumPhysicalGPUs, 0xE5AC921F))
 		{ return; }
 		if (!TryToInitializeFunctionLambda((void**)&NvAPI_EnumLogicalGPUs, 0x48B3EA59))
 		{ return; }
-		if (!TryToInitializeFunctionLambda((void**)&NvAPI_GPU_GetUsages, 0x189A1FDF))
+		// GPU usage query is optional - engine can continue without it (we'll fallback at call sites)
+		if (!TryToInitializeFunctionLambda((void**)&NvAPI_GPU_GetUsages, 0x189A1FDF, /*required=*/false))
 		{ return; }
 		if (!TryToInitializeFunctionLambda((void**)&NvAPI_GPU_PhysicalFromLogical, 0x0AEA3FA32))
 		{ return; }
@@ -95,8 +108,17 @@ void CNvReader::MakeGPUCount()
 
 	for (NvU32 i = 0; i < logicalGPUCount; ++i)
 	{
-		NvAPI_GPU_PhysicalFromLogical(gpuHandlesLg[i], gpuHandlesPh, &AdapterID);
-		AdapterFinal = std::max(AdapterFinal, (u64)AdapterID);
+		// NvAPI_GPU_PhysicalFromLogical is required during init; if for some reason it's null,
+		// fall back to assuming a single GPU to avoid crashes.
+		if (NvAPI_GPU_PhysicalFromLogical)
+		{
+			NvAPI_GPU_PhysicalFromLogical(gpuHandlesLg[i], gpuHandlesPh, &AdapterID);
+			AdapterFinal = std::max(AdapterFinal, (u64)AdapterID);
+		}
+		else
+		{
+			AdapterFinal = std::max(AdapterFinal, (u64)1);
+		}
 	}
 
 	if (AdapterFinal > 1)
@@ -107,6 +129,13 @@ void CNvReader::MakeGPUCount()
 
 u32 CNvReader::GetPercentActive()
 {
+	// NvAPI_GPU_GetUsages may be optional/unavailable in some environments (Wine / shim).
+	// If it's not present, return 0 (no usage info) instead of crashing.
+	if (NvAPI_GPU_GetUsages == nullptr)
+	{
+		return 0;
+	}
+
 	(*NvAPI_GPU_GetUsages)(gpuHandlesPh[0], gpuUsages);
 	int usage = gpuUsages[3];
 	return (u32)usage;


### PR DESCRIPTION
…when the nvapi_QueryInterface exists but specific function IDs (notably `NVAPI_GPU_GetUsages 0x189A1FDF`) are missing. 
### Proposed changes / Предлагаемые изменения

The proposed code now treats that GPU usage function as optional, logs a warning instead of aborting, and guards runtime call sites to avoid crashes under Wine/dxvk-nvapi 0.9.0. This keeps the change small and low risk and is designed to avoid crashes when the shim doesn't implement that ID.

### Associated issues / Ассоциированные проблемы

```
! Found nvapi64.dll, but DLL missing Func ID "412753887"
```
Under wine+DXVK-NVAPI

### Testing / Тестирование

- [ ] Manual testing / Ручное тестирование

> [!IMPORTANT]
> I have not tested those mods yet. You can probably tests them before I am able to produce Windows executables for the game under Linux...

### Agreements / Согласия

- I agree to follow this project's [__Contributing Guidelines__](../CONTRIBUTING.md) /
Я согласен(-на) следовать [__Рекомендациям по внесению вклада в этот проект__](../CONTRIBUTING.rus.md)
- I agree to follow this project's [__Code of Conduct__](../CODE_OF_CONDUCT.md) /
Я согласен(-на) следовать [__Кодексу поведения этого проекта__](../CODE_OF_CONDUCT.rus.md)
