### PR TITLE
Fix verical slot icons issue

### DIFF
--- a/src/Editors/LevelEditor/Editor/Tools/AIMap/ESceneAIMapTools.cpp
+++ b/src/Editors/LevelEditor/Editor/Tools/AIMap/ESceneAIMapTools.cpp
@@ -475,6 +475,10 @@ bool ESceneAIMapTool::LoadStream(IReader& F)
         m_SmoothHeight = F.r_float();
     }
 
+    hash_FillFromNodes();
+
+    IsLoaded = true;
+
     // snap objects
     if (F.find_chunk(AIMAP_CHUNK_SNAP_OBJECTS)) 
     {
@@ -508,9 +512,6 @@ bool ESceneAIMapTool::LoadStream(IReader& F)
         }
     }
 
-    hash_FillFromNodes();
-
-    IsLoaded = true;
     return true;
 }
 

--- a/src/Editors/LevelEditor/Editor/Tools/Base/ESceneCustomOTools.cpp
+++ b/src/Editors/LevelEditor/Editor/Tools/Base/ESceneCustomOTools.cpp
@@ -309,26 +309,39 @@ int ESceneCustomOTool::LockObjects(bool flag, bool bAllowSelectionFlag, bool bSe
 
 CCustomObject* ESceneCustomOTool::FindObjectByName(LPCSTR name, CCustomObject* pass)
 {
-	ObjectIt _I = m_Objects.begin();
-    ObjectIt _E = m_Objects.end();
-	for(;_I!=_E;_I++) 
-    {
-    	CCustomObject* CO = (*_I);
-    	LPCSTR _name = CO->GetName();
+    xr_atomic_bool bFound = false;
+    CCustomObject* Result = nullptr;
 
-        if (!_name || _name == "" || _name == " ")
+    xr_parallel_foreach
+    (
+        m_Objects.begin(), m_Objects.end(),
+        [&](CCustomObject* CO)
         {
-            Msg("!!! Error _name = %s, %s, %s", Scene->GetOTool(CO->FClassID)->ClassName(), CO->GetName(), CO->FName);
-            Msg("!!! Try FIX name");
-            CO->SetName(Scene->GetOTool(CO->FClassID)->ClassName());
-            _name = CO->GetName();
-        }
+            if (bFound)
+            {
+                return;
+            }
 
-        R_ASSERT3(_name, "Invalid object name, position:", (std::to_string(CO->GetPosition().x) + ", " + std::to_string(CO->GetPosition().y) + ", " + std::to_string(CO->GetPosition().z)).c_str());
-    	if((pass!=*_I) && (0==strcmp(_name,name)) ) 
-        	return (*_I);
-    }
-    return 0;
+            shared_str _name = CO->GetName();
+
+            if (!_name || _name == "" || _name == " ")
+            {
+                Msg("!!! Error _name = %s, %s, %s", Scene->GetOTool(CO->FClassID)->ClassName(), CO->GetName(), CO->FName);
+                Msg("!!! Try FIX name");
+                CO->SetName(Scene->GetOTool(CO->FClassID)->ClassName());
+                _name = CO->GetName();
+            }
+
+            R_ASSERT3(_name, "Invalid object name, position:", (std::to_string(CO->GetPosition().x) + ", " + std::to_string(CO->GetPosition().y) + ", " + std::to_string(CO->GetPosition().z)).c_str());
+            if ((pass != CO) && (0 == strcmp(*_name, name)))
+            {
+                Result = CO;
+                bFound = true;
+            }
+        }
+    );
+
+    return Result;
 }
 
 void setEditable(PropItemVec& items, u32 start_idx, bool bEditableTool, bool bObjectInGroup, bool bObjectInGroupUnique)

--- a/src/Editors/LevelEditor/Editor/Utils/Gizmo/IM_Manipulator.cpp
+++ b/src/Editors/LevelEditor/Editor/Utils/Gizmo/IM_Manipulator.cpp
@@ -33,7 +33,7 @@ void IM_Manipulator::Render(float canvasX, float canvasY, float canvasWidth, flo
 	{
 		for (SAINode* Node : ToolBase->Nodes())
 		{
-			if (Node->flags.test(SAINode::flSelected))
+			if (Node && Node->flags.test(SAINode::flSelected))
 			{
 				ObjectMatrix.c = Node->Pos;
 				NodeObject = Node;

--- a/src/Layers/xrRenderDX9/dx9Texture.cpp
+++ b/src/Layers/xrRenderDX9/dx9Texture.cpp
@@ -205,7 +205,7 @@ const char* D3DFormatToString(D3DFORMAT format) {
     return it != formatMap.end() ? it->second : "D3DFMT_UNKNOWN";
 }
 
-void PrintTextureError(HRESULT hr, const char* fname, const void* ddsData, size_t ddsSize, IDirect3DBaseTexture9* pTexture = nullptr)
+void PrintTextureError(HRESULT hr, const char* fname, const void* ddsData, size_t ddsSize, IDirect3DBaseTexture9* pTexture = nullptr, bool PrintMem = true)
 {
     // Получаем возможности устройства
     D3DCAPS9 caps;
@@ -223,7 +223,7 @@ void PrintTextureError(HRESULT hr, const char* fname, const void* ddsData, size_
     Msg(msg);
 
     // Анализируем DDS заголовок
-    if (ddsData && ddsSize >= sizeof(DWORD) + sizeof(DDS_HEADER))
+    if (PrintMem && ddsData && ddsSize >= sizeof(DWORD) + sizeof(DDS_HEADER))
     {
         const DWORD* magic = reinterpret_cast<const DWORD*>(ddsData);
         const DDS_HEADER* header = reinterpret_cast<const DDS_HEADER*>(magic + 1);
@@ -461,7 +461,7 @@ _DDS:
 
             if (FAILED(result) || T_sysmem == nullptr)
             {
-                PrintTextureError(result, fname, bitData, bitSize, pTexture2D);
+                PrintTextureError(result, fname, bitData, bitSize, pTexture2D, T_sysmem != nullptr);
 
                 string_path temp;
                 R_ASSERT(FS.exist(temp, "$game_textures$", "ed\\ed_not_existing_texture", ".dds"));

--- a/src/Layers/xrRenderDX9/dx9Texture.cpp
+++ b/src/Layers/xrRenderDX9/dx9Texture.cpp
@@ -452,11 +452,14 @@ _DDS:
 
             FS.r_close(S);
 
-            img_loaded_lod = get_texture_load_lod(fn);
-            pTexture2D = TW_LoadTextureFromTexture(T_sysmem, img_loaded_lod);
-            mip_cnt = pTexture2D->GetLevelCount();
+            if (T_sysmem != nullptr)
+            {
+                img_loaded_lod = get_texture_load_lod(fn);
+                pTexture2D = TW_LoadTextureFromTexture(T_sysmem, img_loaded_lod);
+                mip_cnt = pTexture2D->GetLevelCount();
+            }
 
-            if (FAILED(result))
+            if (FAILED(result) || T_sysmem == nullptr)
             {
                 PrintTextureError(result, fname, bitData, bitSize, pTexture2D);
 

--- a/src/xrGame/ui/UIDragDropListEx.cpp
+++ b/src/xrGame/ui/UIDragDropListEx.cpp
@@ -618,21 +618,28 @@ void CUICellContainer::PlaceItemAtPos(CUICellItem* itm, Ivector2& cell_pos)
 			C.SetItem		(itm,(x==0&&y==0));
 		}
 	}
-	itm->SetWndSize			( Fvector2().set( (m_cellSize.x*cs.x),		(m_cellSize.y*cs.y)		 )	);
-
-	// FX: (Отступ + размер) * позиция грида... Логично
-	Fvector2 ValidItemPos = { float((m_cellSpacing.x + m_cellSize.x) * cell_pos.x), float(((m_cellSpacing.y + m_cellSize.y) * cell_pos.y)) };
+	// without this will be double compression on wide screens
+	// solution works only for "quads" cells
+	if (m_pParentDragDropList->GetVerticalPlacement())
+	{
+		itm->SetWndSize			( Fvector2().set( (m_cellSize.y*cs.x),		(m_cellSize.y*cs.y)		 )	);
+	}
+	else
+	{
+		itm->SetWndSize			( Fvector2().set( (m_cellSize.x*cs.x),		(m_cellSize.y*cs.y)		 )	);	
+	}
 
 	if (!m_pParentDragDropList->GetVirtualCells()) {
+		// FX: (Отступ + размер) * позиция грида... Логично
+		Fvector2 ValidItemPos = { float((m_cellSpacing.x + m_cellSize.x) * cell_pos.x), float(((m_cellSpacing.y + m_cellSize.y) * cell_pos.y)) };
 		itm->SetWndPos(ValidItemPos);
 	}
 	else
 	{
-		Fvector2 WndSize = m_pParentDragDropList->GetWndSize();
-		Fvector2 AlignPos = WndSize;
+		Fvector2 AlignPos = m_pParentDragDropList->GetWndSize();;
 
 		// FX: We get the coordinates from the center of the window, taking into account the size of the item
-		AlignPos.sub(itm->GetWndSize());
+		AlignPos.sub(Fvector2().set(m_cellSize.x * cs.x,m_cellSize.y * cs.y));
 		AlignPos.div(2);
 
 		itm->SetWndPos(AlignPos);


### PR DESCRIPTION
### Proposed changes / Предлагаемые изменения
- Fix bug with double compression of item icons draawing in vertical slots on wide screens / Исправлен баг с двойным сжатием иконки предмента по ширине в вертикальный слотах

### Associated issues / Ассоциированные проблемы
- 

### Testing / Тестирование
- [x] Manual testing / Ручное тестирование

### Agreements / Согласия
- I agree to follow this project's [__Contributing Guidelines__](../CONTRIBUTING.md) /
Я согласен(-на) следовать [__Рекомендациям по внесению вклада в этот проект__](../CONTRIBUTING.rus.md)
- I agree to follow this project's [__Code of Conduct__](../CODE_OF_CONDUCT.md) /
Я согласен(-на) следовать [__Кодексу поведения этого проекта__](../CODE_OF_CONDUCT.rus.md)
