### PR TITLE
Add support for preferred fallback language

### DIFF
--- a/gamedata/configs/engine_external.ltx
+++ b/gamedata/configs/engine_external.ltx
@@ -70,6 +70,9 @@ FontAtlasSize = 4096
 [environment]
 ReadSunConfig = false
 
+[localization]
+PreferedFallbackLanguage = eng
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extended sections
 

--- a/src/xrEngine/EngineExternal.cpp
+++ b/src/xrEngine/EngineExternal.cpp
@@ -52,6 +52,11 @@ const char* CEngineExternal::GetPlayerHudOmfAdditional() const
 	return READ_IF_EXISTS(pOptions, r_string_wb, "player_hud", "PlayerHudOmfAdditional", "").c_str();
 }
 
+const char* CEngineExternal::GetPreferredFallbackLanguage() const
+{
+	return READ_IF_EXISTS(pOptions, r_string_wb, "localization", "PreferedFallbackLanguage", "eng").c_str();
+}
+
 const xr_vector<shared_str> CEngineExternal::StepWallmarksMaterials() const
 {
 	xr_vector<shared_str> TempVector;

--- a/src/xrEngine/EngineExternal.h
+++ b/src/xrEngine/EngineExternal.h
@@ -80,6 +80,7 @@ public:
 
 	xr_string GetTitle() const;
 	const char* GetPlayerHudOmfAdditional() const;
+	const char* GetPreferredFallbackLanguage() const;
 	const xr_vector<shared_str> StepWallmarksMaterials() const;
 	const xr_string WallmarkLeft() const;
 	const xr_string WallmarkRight() const;

--- a/src/xrEngine/string_table.cpp
+++ b/src/xrEngine/string_table.cpp
@@ -112,6 +112,9 @@ void CStringTable::Init		()
 	//имя языка, если не задано (nullptr), то первый <text> в <string> в XML
 	pData->m_sLanguage = pSettings->r_string("string_table", "language");
 
+	// Get preferred fallback language from EngineExternal
+	pData->m_sFallbackLanguage = EngineExternal().GetPreferredFallbackLanguage();
+
 	auto it = std::find_if(languages_token.begin(), languages_token.end(), [](const xr_token& item) {
 		return item.name == pData->m_sLanguage;
 	});
@@ -142,6 +145,32 @@ void CStringTable::Init		()
 		xr_strcat(fn, ext);
 
 		Load(fn);
+	}
+
+	// Load fallback language files if fallback language is different from main language
+	if (pData->m_sFallbackLanguage.size() > 0 && 
+	    xr_strcmp(pData->m_sLanguage.c_str(), pData->m_sFallbackLanguage.c_str()) != 0)
+	{
+		FS_FileSet fallback_fset;
+		FS_FileSet fallback_efset;
+
+		xr_sprintf(files_mask, "text\\%s\\*.xml", pData->m_sFallbackLanguage.c_str());
+		FS.file_list(fallback_fset, "$game_config$", FS_ListFiles, files_mask);
+
+		xr_sprintf(exclude_files_mask, "text\\%s\\mod_*.xml", pData->m_sFallbackLanguage.c_str());
+		FS.file_list(fallback_efset, "$game_config$", FS_ListFiles, exclude_files_mask);
+
+		for (const FS_File& File : fallback_fset)
+		{
+			if (fallback_efset.contains(File))
+				continue;
+
+			string_path fn, ext;
+			_splitpath(File.name.c_str(), 0, 0, fn, ext);
+			xr_strcat(fn, ext);
+
+			LoadFallback(fn);
+		}
 	}
 
 	ReparseKeyBindings();
@@ -179,6 +208,42 @@ void CStringTable::Load	(LPCSTR xml_file_full)
 		STRING_VALUE str_val		= ParseLine(string_text, string_name, true);
 		
 		pData->m_StringTable[string_name] = str_val;
+	}
+}
+
+void CStringTable::LoadFallback	(LPCSTR xml_file_full)
+{
+	CXml						uiXml;
+	string_path					_s;
+	xr_strconcat(_s, "text\\", pData->m_sFallbackLanguage.c_str() );
+
+	uiXml.Load					(CONFIG_PATH, _s, xml_file_full);
+
+	//общий список всех записей таблицы в файле
+	int string_num = uiXml.GetNodesNum		(uiXml.GetRoot(), "string");
+
+	for(int i=0; i<string_num; ++i)
+	{
+		LPCSTR string_name = uiXml.ReadAttrib(uiXml.GetRoot(), "string", i, "id", nullptr);
+
+		bool isDublicate = pData->m_FallbackStringTable.find(string_name) != pData->m_FallbackStringTable.end();
+		if (isDublicate)
+		{
+			//VERIFY3(!isDublicate, "duplicate string table id", string_name);
+			Msg("! duplicate fallback string table id: %s", string_name);
+		}
+
+		LPCSTR string_text		= uiXml.Read(uiXml.GetRoot(), "string:text", i,  nullptr);
+
+		if(m_bWriteErrorsToLog && string_text)
+			Msg("[fallback string table] '%s' no translation in '%s'", string_name, pData->m_sFallbackLanguage.c_str() );
+		
+		if (string_text != nullptr)
+		{
+			STRING_VALUE str_val		= ParseLine(string_text, string_name, false);
+			
+			pData->m_FallbackStringTable[string_name] = str_val;
+		}
 	}
 }
 
@@ -284,8 +349,17 @@ STRING_VALUE CStringTable::ParseLine(LPCSTR str, LPCSTR skey, bool bFirst)
 
 STRING_VALUE CStringTable::translate (const STRING_ID& str_id) const
 {
-	if(pData != nullptr && pData->m_StringTable.find(str_id)!=pData->m_StringTable.end())
-		return  pData->m_StringTable[str_id];
-	else
-		return str_id;
+	if(pData != nullptr)
+	{
+		// First try to find in main language
+		if(pData->m_StringTable.find(str_id)!=pData->m_StringTable.end())
+			return  pData->m_StringTable[str_id];
+			
+		// If not found and fallback table exists, try fallback language
+		if(pData->m_FallbackStringTable.find(str_id)!=pData->m_FallbackStringTable.end())
+			return  pData->m_FallbackStringTable[str_id];
+	}
+	
+	// If not found in either table, return the original string ID
+	return str_id;
 }

--- a/src/xrEngine/string_table.h
+++ b/src/xrEngine/string_table.h
@@ -11,7 +11,9 @@ using STRING_TABLE_MAP_IT = STRING_TABLE_MAP::iterator;
 struct STRING_TABLE_DATA
 {
 	STRING_VALUE			m_sLanguage;
+	STRING_VALUE			m_sFallbackLanguage;
 	STRING_TABLE_MAP		m_StringTable;
+	STRING_TABLE_MAP		m_FallbackStringTable;
 	STRING_TABLE_MAP		m_string_key_binding;
 };
 
@@ -35,6 +37,7 @@ public:
 private:
 			void				Init					();
 			void				Load					(LPCSTR xml_file);
+			void				LoadFallback			(LPCSTR xml_file);
 	static STRING_VALUE			ParseLine				(LPCSTR str, LPCSTR key, bool bFirst);
 	static STRING_TABLE_DATA*	pData;
 };


### PR DESCRIPTION
This pull request adds support for a preferred fallback language in the game's localization system. If a translation is missing in the main language, the system will now look for it in the fallback language, improving the robustness of localization and user experience. The fallback language is configurable through a new setting.

**Localization fallback language support:**

* Added a new `[localization]` section and `PreferedFallbackLanguage` option to `engine_external.ltx` for specifying the fallback language.
* Exposed `GetPreferredFallbackLanguage()` in `CEngineExternal` to access the fallback language setting from code. 
* Updated `CStringTable` to load and store translations from the fallback language if the main language is missing entries, including logic to avoid loading duplicates and to log missing translations.
* Modified the translation lookup so that if a string is not found in the main language, it will be searched for in the fallback language before defaulting to the string ID.

<del>I was able to build the engine in my CI pipeline with those mods but I can't store the artefacts from my fork. If it builds on your CI, I'll test it quickly but it should work as I've tested it atomically in C++ already.

Works fine apart from accentuation. I don't think it uses utf8 and doesn't seem to be capable of displaying accent like `à é î ö ú`. The menu is not translated as well unless you modify the script manually?

<img width="3440" height="1440" alt="Capture d’écran du 2025-09-13 01-40-24" src="https://github.com/user-attachments/assets/d1424f40-cc82-44b4-9846-a050f5e927bf" />

Fixes* :
```log
XML file:text\fra\ui_st_mm.xml value:(null) errDescr:Error=XML_ERROR_PARSING ErrorID=15 (0xf) Line number=919
```
\* only if the translation is present in the fallback language.