### PR TITLE
Fix `m_MoveSnap` values in editor

### DIFF
--- a/src/Editors/LevelEditor/UI/UIMainForm.cpp
+++ b/src/Editors/LevelEditor/UI/UIMainForm.cpp
@@ -948,6 +948,12 @@ void UIMainForm::DrawRenderToolBar(ImVec2 Pos, ImVec2 Size)
 					ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
 				if (ImGui::Selectable("5", false))
 				{
+					Tools->m_MoveSnap = 5.f;
+				}
+				if (ImGui::IsItemHovered())
+					ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
+				if (ImGui::Selectable("10", false))
+				{
 					Tools->m_MoveSnap = 10.f;
 				}
 				if (ImGui::IsItemHovered())


### PR DESCRIPTION
### Proposed changes / Предлагаемые изменения

В "Fixed object movement" параметру "5" в реальности соответствовало значение 10. Поэтому при выборе этого значения объект перемещался на 10 ячеек сетки вместо 5. Сам же параметр "10" был пропущен.

### Agreements / Согласия

- I agree to follow this project's [__Contributing Guidelines__](../CONTRIBUTING.md) /
Я согласен(-на) следовать [__Рекомендациям по внесению вклада в этот проект__](../CONTRIBUTING.rus.md)
- I agree to follow this project's [__Code of Conduct__](../CODE_OF_CONDUCT.md) /
Я согласен(-на) следовать [__Кодексу поведения этого проекта__](../CODE_OF_CONDUCT.rus.md)
