### PR TITLE
Fix language reload and translate inventory items when switching language 

### DIFF
--- a/gamedata/configs/engine_external.ltx
+++ b/gamedata/configs/engine_external.ltx
@@ -79,6 +79,9 @@ FontAtlasSize = 4096                    ; Texture atlas size value. Must be in t
 [environment]
 ReadSunConfig = false                   ; Enable sun movement in configurations
 
+[localization]
+PreferedFallbackLanguage = eng
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Extended sections
 

--- a/src/xrCore/EngineExternal.cpp
+++ b/src/xrCore/EngineExternal.cpp
@@ -54,6 +54,11 @@ const char* CEngineExternal::GetPlayerHudOmfAdditional() const
 	return READ_IF_EXISTS(pOptions, r_string_wb, "player_hud", "PlayerHudOmfAdditional", "").c_str();
 }
 
+const char* CEngineExternal::GetPreferredFallbackLanguage() const
+{
+	return READ_IF_EXISTS(pOptions, r_string_wb, "localization", "PreferedFallbackLanguage", "eng").c_str();
+}
+
 const xr_vector<shared_str> CEngineExternal::StepWallmarksMaterials() const
 {
 	xr_vector<shared_str> TempVector;

--- a/src/xrCore/EngineExternal.h
+++ b/src/xrCore/EngineExternal.h
@@ -83,6 +83,7 @@ public:
 
 	xr_string GetTitle() const;
 	const char* GetPlayerHudOmfAdditional() const;
+	const char* GetPreferredFallbackLanguage() const;
 	const xr_vector<shared_str> StepWallmarksMaterials() const;
 	const xr_string WallmarkLeft() const;
 	const xr_string WallmarkRight() const;

--- a/src/xrEngine/string_table.cpp
+++ b/src/xrEngine/string_table.cpp
@@ -112,6 +112,9 @@ void CStringTable::Init		()
 	//имя языка, если не задано (nullptr), то первый <text> в <string> в XML
 	pData->m_sLanguage = pSettings->r_string("string_table", "language");
 
+	// Get preferred fallback language from EngineExternal
+	pData->m_sFallbackLanguage = EngineExternal().GetPreferredFallbackLanguage();
+
 	auto it = std::find_if(languages_token.begin(), languages_token.end(), [](const xr_token& item) {
 		return item.name == pData->m_sLanguage;
 	});
@@ -142,6 +145,32 @@ void CStringTable::Init		()
 		xr_strcat(fn, ext);
 
 		Load(fn);
+	}
+
+	// Load fallback language files if fallback language is different from main language
+	if (pData->m_sFallbackLanguage.size() > 0 && 
+	    xr_strcmp(pData->m_sLanguage.c_str(), pData->m_sFallbackLanguage.c_str()) != 0)
+	{
+		FS_FileSet fallback_fset;
+		FS_FileSet fallback_efset;
+
+		xr_sprintf(files_mask, "text\\%s\\*.xml", pData->m_sFallbackLanguage.c_str());
+		FS.file_list(fallback_fset, "$game_config$", FS_ListFiles, files_mask);
+
+		xr_sprintf(exclude_files_mask, "text\\%s\\mod_*.xml", pData->m_sFallbackLanguage.c_str());
+		FS.file_list(fallback_efset, "$game_config$", FS_ListFiles, exclude_files_mask);
+
+		for (const FS_File& File : fallback_fset)
+		{
+			if (fallback_efset.contains(File))
+				continue;
+
+			string_path fn, ext;
+			_splitpath(File.name.c_str(), 0, 0, fn, ext);
+			xr_strcat(fn, ext);
+
+			LoadFallback(fn);
+		}
 	}
 
 	ReparseKeyBindings();
@@ -182,6 +211,42 @@ void CStringTable::Load	(LPCSTR xml_file_full)
 	}
 }
 
+void CStringTable::LoadFallback	(LPCSTR xml_file_full)
+{
+	CXml						uiXml;
+	string_path					_s;
+	xr_strconcat(_s, "text\\", pData->m_sFallbackLanguage.c_str() );
+
+	uiXml.Load					(CONFIG_PATH, _s, xml_file_full);
+
+	//общий список всех записей таблицы в файле
+	int string_num = uiXml.GetNodesNum		(uiXml.GetRoot(), "string");
+
+	for(int i=0; i<string_num; ++i)
+	{
+		LPCSTR string_name = uiXml.ReadAttrib(uiXml.GetRoot(), "string", i, "id", nullptr);
+
+		bool isDublicate = pData->m_FallbackStringTable.find(string_name) != pData->m_FallbackStringTable.end();
+		if (isDublicate)
+		{
+			//VERIFY3(!isDublicate, "duplicate string table id", string_name);
+			Msg("! duplicate fallback string table id: %s", string_name);
+		}
+
+		LPCSTR string_text		= uiXml.Read(uiXml.GetRoot(), "string:text", i,  nullptr);
+
+		if(m_bWriteErrorsToLog && string_text)
+			Msg("[fallback string table] '%s' no translation in '%s'", string_name, pData->m_sFallbackLanguage.c_str() );
+		
+		if (string_text != nullptr)
+		{
+			STRING_VALUE str_val		= ParseLine(string_text, string_name, false);
+			
+			pData->m_FallbackStringTable[string_name] = str_val;
+		}
+	}
+}
+
 void CStringTable::ReparseKeyBindings()
 {
 	if(pData == nullptr)
@@ -200,6 +265,9 @@ void CStringTable::ReloadLanguage(const char* lang)
 
 	pData = new STRING_TABLE_DATA();
 	pData->m_sLanguage = lang;
+
+	// Get preferred fallback language from EngineExternal
+	pData->m_sFallbackLanguage = EngineExternal().GetPreferredFallbackLanguage();
 
 	FS_FileSet fset;
 	FS_FileSet efset;
@@ -223,6 +291,32 @@ void CStringTable::ReloadLanguage(const char* lang)
 		xr_strcat(fn, ext);
 
 		Load(fn);
+	}
+
+	// Load fallback language files if fallback language is different from main language
+	if (pData->m_sFallbackLanguage.size() > 0 && 
+	    xr_strcmp(pData->m_sLanguage.c_str(), pData->m_sFallbackLanguage.c_str()) != 0)
+	{
+		FS_FileSet fallback_fset;
+		FS_FileSet fallback_efset;
+
+		xr_sprintf(files_mask, "text\\%s\\*.xml", pData->m_sFallbackLanguage.c_str());
+		FS.file_list(fallback_fset, "$game_config$", FS_ListFiles, files_mask);
+
+		xr_sprintf(exclude_files_mask, "text\\%s\\mod_*.xml", pData->m_sFallbackLanguage.c_str());
+		FS.file_list(fallback_efset, "$game_config$", FS_ListFiles, exclude_files_mask);
+
+		for (const FS_File& File : fallback_fset)
+		{
+			if (fallback_efset.contains(File))
+				continue;
+
+			string_path fn, ext;
+			_splitpath(File.name.c_str(), 0, 0, fn, ext);
+			xr_strcat(fn, ext);
+
+			LoadFallback(fn);
+		}
 	}
 
 	ReparseKeyBindings();
@@ -284,8 +378,17 @@ STRING_VALUE CStringTable::ParseLine(LPCSTR str, LPCSTR skey, bool bFirst)
 
 STRING_VALUE CStringTable::translate (const STRING_ID& str_id) const
 {
-	if(pData != nullptr && pData->m_StringTable.find(str_id)!=pData->m_StringTable.end())
-		return  pData->m_StringTable[str_id];
-	else
-		return str_id;
+	if(pData != nullptr)
+	{
+		// First try to find in main language
+		if(pData->m_StringTable.find(str_id)!=pData->m_StringTable.end())
+			return  pData->m_StringTable[str_id];
+			
+		// If not found and fallback table exists, try fallback language
+		if(pData->m_FallbackStringTable.find(str_id)!=pData->m_FallbackStringTable.end())
+			return  pData->m_FallbackStringTable[str_id];
+	}
+	
+	// If not found in either table, return the original string ID
+	return str_id;
 }

--- a/src/xrEngine/string_table.h
+++ b/src/xrEngine/string_table.h
@@ -11,7 +11,9 @@ using STRING_TABLE_MAP_IT = STRING_TABLE_MAP::iterator;
 struct STRING_TABLE_DATA
 {
 	STRING_VALUE			m_sLanguage;
+	STRING_VALUE			m_sFallbackLanguage;
 	STRING_TABLE_MAP		m_StringTable;
+	STRING_TABLE_MAP		m_FallbackStringTable;
 	STRING_TABLE_MAP		m_string_key_binding;
 };
 
@@ -35,6 +37,7 @@ public:
 private:
 			void				Init					();
 			void				Load					(LPCSTR xml_file);
+			void				LoadFallback			(LPCSTR xml_file);
 	static STRING_VALUE			ParseLine				(LPCSTR str, LPCSTR key, bool bFirst);
 	static STRING_TABLE_DATA*	pData;
 };

--- a/src/xrGame/Inventory.cpp
+++ b/src/xrGame/Inventory.cpp
@@ -919,6 +919,16 @@ void CInventory::Update()
 	UpdateDropTasks	();
 }
 
+void CInventory::RefreshTranslations()
+{
+	// Refresh translations for all items in inventory after language change
+	for (PIItem item : m_all)
+	{
+		if (item)
+			item->RefreshTranslations();
+	}
+}
+
 void CInventory::UpdateDropTasks()
 {
 	//проверить слоты

--- a/src/xrGame/Inventory.h
+++ b/src/xrGame/Inventory.h
@@ -79,6 +79,7 @@ public:
 	bool					Action				(u16 cmd, u32 flags);
 	void					ActiveWeapon		(u16 slot);
 	void					Update				();
+	void					RefreshTranslations	();	// Refresh all item translations after language change
 	// »щет на по€се аналогичный IItem
 	PIItem					Same				(const PIItem pIItem, bool bSearchRuck) const;
 	// »щет на по€се IItem дл€ указанного слота

--- a/src/xrGame/InventoryOwner.cpp
+++ b/src/xrGame/InventoryOwner.cpp
@@ -249,6 +249,12 @@ void CInventoryOwner::RefreshNamesNPC()
 	m_game_name = TranslateName(m_game_name_str.c_str());
 }
 
+void CInventoryOwner::RefreshInventoryTranslations()
+{
+	if (m_inventory)
+		m_inventory->RefreshTranslations();
+}
+
 //достать PDA из специального слота инвентаря
 CPda* CInventoryOwner::GetPDA() const
 {

--- a/src/xrGame/InventoryOwner.h
+++ b/src/xrGame/InventoryOwner.h
@@ -73,6 +73,7 @@ public:
 	virtual void	load						(IReader &input_packet);
 
 			void	RefreshNamesNPC();
+			void	RefreshInventoryTranslations();
 
 	//обновление
 	virtual void	UpdateInventoryOwner		(u32 deltaT);

--- a/src/xrGame/console_commands.cpp
+++ b/src/xrGame/console_commands.cpp
@@ -2296,7 +2296,7 @@ public:
 };
 #endif
 
-extern void RefreshNamesNPC();
+extern void RefreshNames();
 extern void execute_console_command_deferred(CConsole* c, LPCSTR string_to_execute);
 
 class CCC_ChangeLanguage : public CCC_Token
@@ -2349,7 +2349,7 @@ public:
 		
 		if (g_pGameLevel != nullptr)
 		{
-			RefreshNamesNPC();
+			RefreshNames();
 		}
 	}
 

--- a/src/xrGame/inventory_item.cpp
+++ b/src/xrGame/inventory_item.cpp
@@ -262,6 +262,24 @@ void CInventoryItem::ReadCustomTextAndMarks(LPCSTR section) {
 	m_custom_mark_clr				= READ_IF_EXISTS(pSettings, r_color, section, "item_custom_mark_clr", 0);
 }
 
+void CInventoryItem::RefreshTranslations()
+{
+	// Re-translate the cached strings after language change
+	if (!m_section_id.size())
+		return;
+
+	LPCSTR section = m_section_id.c_str();
+	
+	if (pSettings->line_exist(section, "inv_name"))
+		m_name = g_pStringTable->translate(pSettings->r_string(section, "inv_name"));
+
+	if (pSettings->line_exist(section, "inv_name_short"))
+		m_nameShort = g_pStringTable->translate(pSettings->r_string(section, "inv_name_short"));
+
+	if (pSettings->line_exist(section, "description"))
+		m_Description = g_pStringTable->translate(pSettings->r_string(section, "description"));
+}
+
 void  CInventoryItem::ChangeCondition(float fDeltaCondition)
 {
 	m_fCondition += fDeltaCondition;

--- a/src/xrGame/inventory_item.h
+++ b/src/xrGame/inventory_item.h
@@ -110,6 +110,7 @@ public:
 public:
 	virtual void				Load				(LPCSTR section);
 			void				ReadCustomTextAndMarks(LPCSTR section);
+			void				RefreshTranslations	();
 
 			// Дополнение описания предмета для кастомизации через скрипты к основному описанию в UIItemInfo.cpp
 			void				SetAdditionalDescription(LPCSTR additionalDescription);

--- a/src/xrGame/level_script.cpp
+++ b/src/xrGame/level_script.cpp
@@ -1099,10 +1099,24 @@ void ReloadLanguage(const char* lang)
 	g_pStringTable->ReloadLanguage(lang);
 }
 
-void RefreshNamesNPC()
+void RefreshNames()
 {
+	if (g_pGameLevel == nullptr)
+		return;
+
 	for (auto& [id, pointer] : ai().alife().objects().objects())
 	{
+		const auto obj = g_pGameLevel->Objects.net_Find(id);
+		if (obj != nullptr)
+		{
+			auto* owner = obj->cast_inventory_item();
+			if (owner)
+			{
+				owner->RefreshTranslations();
+				continue;
+			}
+		}
+
 		auto trader = pointer->cast_trader_abstract();
 		if (trader == nullptr)
 		{
@@ -1110,12 +1124,7 @@ void RefreshNamesNPC()
 		}
 
 		trader->m_character_name = TranslateName(trader->m_character_name_raw.c_str());
-		if (g_pGameLevel == nullptr)
-		{
-			continue;
-		}
 
-		const auto obj = g_pGameLevel->Objects.net_Find(id);
 		if (obj != nullptr)
 		{
 			CInventoryOwner* owner = obj->cast_inventory_owner();


### PR DESCRIPTION
### Proposed changes

This pull request adds robust support for refreshing item translations when the game language changes, ensuring that inventory item names and descriptions are properly updated. The changes introduce new methods to inventory-related classes, extend the language reload logic to handle fallback languages, and update the language change console command to refresh both NPC and inventory item translations.

**Language reload and fallback support:**

* Enhanced `CStringTable::ReloadLanguage` to load translation files for a preferred fallback language if it's different from the main language, improving localization reliability.

**Inventory item translation refresh:**

* Added `CInventoryItem::RefreshTranslations` to re-translate cached strings for item names and descriptions after a language change.
* Implemented `CInventory::RefreshTranslations` to refresh translations for all items in the inventory, and exposed this via `CInventoryOwner::RefreshInventoryTranslations`.

**Console command integration:**

* Updated the language change console command to invoke both `RefreshNamesNPC` and the new `RefreshInventoryItemTranslations` function, ensuring all relevant translations are updated immediately after a language switch.

### Associated issues
- #205 

### Testing 

- [X] Manual testing

### Agreements 

- I agree to follow this project's [__Contributing Guidelines__](../CONTRIBUTING.md) 
- I agree to follow this project's [__Code of Conduct__](../CODE_OF_CONDUCT.md) 
