### PR TITLE
Расширен функционал подсказок при наведении на предмет через LUA

### DIFF
--- a/src/xrGame/inventory_item.cpp
+++ b/src/xrGame/inventory_item.cpp
@@ -63,6 +63,9 @@ CInventoryItem::CInventoryItem()
 	m_ItemCurrPlace.slot_id			= NO_ACTIVE_SLOT;
 
 	m_Description					= "";
+	m_IsUsedAdditionalDescription	= false;
+	m_AdditionalDescription			= "";
+	m_ExtendedUnionDescription		= "";
 	m_section_id					= 0;
 	m_flags.set						(FIsHelperItem,FALSE);
 	m_flags.set						(FCanStack, TRUE);
@@ -194,6 +197,35 @@ void CInventoryItem::Load(LPCSTR section)
 	m_inv_rect.set(inv_grid_x, inv_grid_y, inv_grid_width, inv_grid_height);
 	
 	ReadCustomTextAndMarks		(section);
+}
+
+LPCSTR CInventoryItem::GetAdditionalDescription()
+{
+	return m_AdditionalDescription.c_str();
+}
+
+void CInventoryItem::SetAdditionalDescription(LPCSTR additionalDescription)
+{
+	m_AdditionalDescription = additionalDescription;
+	m_IsUsedAdditionalDescription = xr_strcmp(m_AdditionalDescription, "") != 0;
+
+	if (m_IsUsedAdditionalDescription)
+		m_ExtendedUnionDescription = make_string<const char*>("%s\\n\\n%s", m_Description.c_str(), m_AdditionalDescription.c_str());
+}
+
+void CInventoryItem::UnsetAdditionalDescription()
+{
+	SetAdditionalDescription("");
+}
+
+bool CInventoryItem::IsUsedAdditionalDescription()
+{
+	return m_IsUsedAdditionalDescription;
+}
+
+shared_str CInventoryItem::GetExtendedUnionDescription()
+{
+	return m_ExtendedUnionDescription;
 }
 
 void CInventoryItem::ReadCustomTextAndMarks(LPCSTR section) {

--- a/src/xrGame/inventory_item.h
+++ b/src/xrGame/inventory_item.h
@@ -111,9 +111,17 @@ public:
 	virtual void				Load				(LPCSTR section);
 			void				ReadCustomTextAndMarks(LPCSTR section);
 
+			// Дополнение описания предмета для кастомизации через скрипты к основному описанию в UIItemInfo.cpp
+			void				SetAdditionalDescription(LPCSTR additionalDescription);
+			void				UnsetAdditionalDescription();
+			bool				IsUsedAdditionalDescription();
+			LPCSTR				GetAdditionalDescription();
+			shared_str			GetExtendedUnionDescription();
+
 			LPCSTR				NameItem			();// remove <virtual> by sea
 			LPCSTR				NameShort			();
 	shared_str					ItemDescription		() { return m_Description; }
+	shared_str					ItemDescriptionAdditional() { return m_AdditionalDescription; }
 	virtual bool				GetBriefInfo		(II_BriefInfo& info) { info.clear(); return false; }
 	
 	virtual void				OnEvent				(NET_Packet& P, u16 type);
@@ -232,6 +240,9 @@ protected:
 	float						m_weight;
 	float						m_fCondition;
 	shared_str					m_Description;
+	shared_str					m_AdditionalDescription;
+	shared_str					m_ExtendedUnionDescription;
+	bool						m_IsUsedAdditionalDescription;
 protected:
 	ALife::_TIME_ID				m_dwItemIndependencyTime;
 

--- a/src/xrGame/script_game_object.cpp
+++ b/src/xrGame/script_game_object.cpp
@@ -375,6 +375,46 @@ u32 CScriptGameObject::GetAmmoElapsed()
 }
 
 //FFx0001++
+LPCSTR CScriptGameObject::GetItemAdditionalDescription()
+{
+	if (CInventoryItem* inventory_item = object().cast_inventory_item())
+	{
+		return inventory_item->GetAdditionalDescription();
+	}
+
+	return "";
+}
+
+//FFx0001++
+void CScriptGameObject::SetItemAdditionalDescription(LPCSTR additionalDescription)
+{
+	if (CInventoryItem* inventory_item = object().cast_inventory_item())
+	{
+		inventory_item->SetAdditionalDescription(additionalDescription);
+	}
+}
+
+//FFx0001++
+void CScriptGameObject::UnsetItemAdditionalDescription()
+{
+	if (CInventoryItem* inventory_item = object().cast_inventory_item())
+	{
+		inventory_item->UnsetAdditionalDescription();
+	}
+}
+
+//FFx0001++
+bool CScriptGameObject::IsItemUsedAdditionalDescription()
+{
+	if (CInventoryItem* inventory_item = object().cast_inventory_item())
+	{
+		inventory_item->IsUsedAdditionalDescription();
+	}
+
+	return false;
+}
+
+//FFx0001++
 u32 CScriptGameObject::GetAmmoElapsedWithChamber()
 {
 	if (const CWeapon* weapon = object().cast_weapon())

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -475,6 +475,11 @@ public:
 //////////////////////////////////////////////////////////////////////////
 
 			LPCSTR				GetPatrolPathName	();
+			LPCSTR				GetItemAdditionalDescription();
+			void				SetItemAdditionalDescription(LPCSTR additionalDescription);
+			void				UnsetItemAdditionalDescription();
+			bool				IsItemUsedAdditionalDescription();
+
 			u32					GetAmmoElapsed		();
 			u32					GetAmmoElapsedWithChamber(); // FFx0001 ++
 			bool				IsWeaponUseChamber(); // FFx0001 ++

--- a/src/xrGame/script_game_object_script2.cpp
+++ b/src/xrGame/script_game_object_script2.cpp
@@ -147,6 +147,12 @@ class_<CScriptGameObject> script_register_game_object1(class_<CScriptGameObject>
 
 		.def("patrol",						&CScriptGameObject::GetPatrolPathName)
 
+		//FFx0001++
+		.def("get_item_additional_description", &CScriptGameObject::GetItemAdditionalDescription)
+		.def("set_item_additional_description", &CScriptGameObject::SetItemAdditionalDescription)
+		.def("unset_item_additional_description", &CScriptGameObject::UnsetItemAdditionalDescription)
+		.def("is_item_used_additional_description", &CScriptGameObject::IsItemUsedAdditionalDescription)
+
 		.def("get_ammo_in_magazine",		&CScriptGameObject::GetAmmoElapsed)
 		.def("get_ammo_in_magazine_and_chamber", &CScriptGameObject::GetAmmoElapsedWithChamber) //FFx0001++
 		.def("is_weapon_use_chamber",			 &CScriptGameObject::IsWeaponUseChamber) //FFx0001++

--- a/src/xrGame/ui/UIItemInfo.cpp
+++ b/src/xrGame/ui/UIItemInfo.cpp
@@ -314,7 +314,7 @@ void CUIItemInfo::InitItem(CUICellItem* pCellItem, CInventoryItem* pCompareItem,
 			pItem->SetFont						(m_desc_info.pDescFont);
 			pItem->SetWidth						(UIDesc->GetDesiredChildWidth());
 			pItem->SetTextComplexMode			(true);
-			pItem->SetText						(*pInvItem->ItemDescription());
+			pItem->SetText(pInvItem->IsUsedAdditionalDescription() ? *pInvItem->GetExtendedUnionDescription() : *pInvItem->ItemDescription());
 			pItem->AdjustHeightToText			();
 			UIDesc->AddWindow					(pItem, true);
 		}


### PR DESCRIPTION
Теперь можно добавлять кастомный вычисляемый дополнительный текст.
Полезно для авто генерации дополнительных динамических характеристик предмета.

### Proposed changes / Предлагаемые изменения
-- Получить строку дополнительного описания установленного на инвентарный предмет.
CGameObject::get_item_additional_description():string

-- Установить строку дополнительного описания на инвентарный предмет.
CGameObject::set_item_additional_description(string): void

-- Очистить строку дополнительного описания установленного на инвентарный предмет.
CGameObject::unset_item_additional_description(): void

-- Установлена ли строка дополнительного описания на инвентарный предмет.
CGameObject::is_item_used_additional_description(): bool

### Testing / Тестирование.
[x] Manual testing / Ручное тестирование

Пример корректного оптимального использования:

``` LUA:
-- подписываемся на коллбек наведения на предмет мыши
function on_game_start()
	RegisterScriptCallback("CUIActorMenu_OnItemFocusReceive", this.on_item_focus_receive)
end

-- устанавливаем доп текст на предмет при наведении 
function on_item_focus_receive(item_game_object)
        -- пример установки кастомного дополнительного текста на предмет по имени секции, в реальном проекте можно сделать более сложную продуманную логику к примеру в зависимости от износа в характеристаках отображать эффективность ремонта чем либо и т.п.
        local trigger_section = "itm_repair_kit_03" 
	if item_game_object and item_game_object:id() and item_game_object:section() == trigger_section  then
		local min_repair_condition = 30 -- наше кастомное изменяемое со скрипта значение в нашем переведенном тексте
		local characteristics = {
			game.translate_string("st_additional_characteristics"),
			game.translate_string("st_characteristic_category_repair_kit"),
			game.translate_string("st_characteristic_min_condition_repair_kit") .. tostring(min_repair_condition) .. " %",
		}
		
		item_game_object:set_item_additional_description(table.concat(characteristics, ""))
	end
end
```

``` XML:
<string id="st_additional_characteristics">
		<text> \n%c[255,255,255,255]Характеристики: </text>
</string>

<string id="st_characteristic_category_repair_kit">
		<text> \n%c[255,255,255,255]• %c[255,255,255,255] Ремонт снаряжения </text>
</string>

<string id="st_characteristic_min_condition_repair_kit">
		<text> \n%c[255,255,255,255]• %c[255,255,255,255] Минимальный порог использования: </text>
</string>
```

На выходе получим дополнение к описанию предмета в таком виде
```
предшествующее описание из конфига + сгенерированное
<text>
	\n%c[255,255,255,255]Характеристики: 
	\n%c[255,255,255,255]• %c[255,255,255,255] Ремонт снаряжения 
	\n%c[255,255,255,255]• %c[255,255,255,255] Минимальный порог использования: 30 %
</text>
```