### PR TITLE
Переработаны лодауты (Восстановлен режим который должен был быть в Co…

### DIFF
--- a/gamedata/configs/engine_external.ltx
+++ b/gamedata/configs/engine_external.ltx
@@ -63,8 +63,13 @@ EnableInventoryPistolSlot = false       ; 2nd slot for pistols only (like in CS/
 EnableImproveWeaponMisfire = false      ; Gunslinger Mod Style
 EnableDelayedWeaponActions = false      ; Gunslinger Mod Style
 EnableLegacyUpgradeSystem = false		; Use upgrade system from Clear Sky
-EnableLoadoutsForSpawnSupplies = true			; Use loadouts for npc profiles
-EnableCocStyleForLoadoutsSpawnSupplies = true	; spawn once random item section by once random loadout OR spawn all items sections by once random loadout
+
+[spawn_supplies]
+EnableLoadoutsSupplies 						= true; Use loadouts for npc profiles
+;; select one option ;;
+EnableSpawnFullRandomLoadout				= false; Spawn all sections by once random loadout included for npc 
+EnableSpawnOnceRandomItemPerEachLoadouts	= true; Spawn by one item each loadouts included for npc (CoC Style)
+EnableSpawnOnceRandomitemByRandomLoadout	= false; Spawn once random item by all included loadouts for npc
 
 ; Dialogs
 DialogFovScale = 0.75                   ; Increasing fov during dialogue

--- a/gamedata_cs/configs/engine_external.ltx
+++ b/gamedata_cs/configs/engine_external.ltx
@@ -62,8 +62,13 @@ EnableInventoryPistolSlot = true        ; 2nd slot for pistols only (like in CS/
 EnableImproveWeaponMisfire = false		; Gunslinger Mod Style
 EnableDelayedWeaponActions = false		; Gunslinger Mod Style
 EnableLegacyUpgradeSystem = true		; Use upgrade system from Clear Sky
-EnableLoadoutsForSpawnSupplies = true			; Use loadouts for npc profiles
-EnableCocStyleForLoadoutsSpawnSupplies = true	; spawn once random item section by once random loadout OR spawn all items sections by once random loadout
+
+[spawn_supplies]
+EnableLoadoutsSupplies 						= true; Use loadouts for npc profiles
+;; select one option ;;
+EnableSpawnFullRandomLoadout				= false; Spawn all sections by once random loadout included for npc 
+EnableSpawnOnceRandomItemPerEachLoadouts	= true; Spawn by one item each loadouts included for npc (CoC Style)
+EnableSpawnOnceRandomitemByRandomLoadout	= false; Spawn once random item by all included loadouts for npc
 
 ; Dialogs
 DialogFovScale = 0.75 ; Increasing fov during dialogue

--- a/src/xrCore/EngineExternal.cpp
+++ b/src/xrCore/EngineExternal.cpp
@@ -124,6 +124,11 @@ bool CEngineExternal::operator[](const EEngineExternalGame& ID) const
 	return READ_IF_EXISTS(pOptions, r_bool, "gameplay", magic_enum::enum_name(ID).data(), false);
 }
 
+bool CEngineExternal::operator[](const EEngineExternalSpawnSupplies& ID) const
+{
+	return READ_IF_EXISTS(pOptions, r_bool, "spawn_supplies", magic_enum::enum_name(ID).data(), false);
+}
+
 bool CEngineExternal::operator[](const EEngineExternalRender& ID) const
 {
 	return READ_IF_EXISTS(pOptions, r_bool, "render", magic_enum::enum_name(ID).data(), false);

--- a/src/xrCore/EngineExternal.h
+++ b/src/xrCore/EngineExternal.h
@@ -20,6 +20,14 @@ enum class EEngineExternalPhysical
 	None
 };
 
+enum class EEngineExternalSpawnSupplies
+{
+	EnableLoadoutsSupplies,
+	EnableSpawnFullRandomLoadout,
+	EnableSpawnOnceRandomItemPerEachLoadouts,
+	EnableSpawnOnceRandomitemByRandomLoadout
+};
+
 enum class EEngineExternalGame
 {
 	EnableThirst,
@@ -38,8 +46,6 @@ enum class EEngineExternalGame
 	EnableImproveWeaponMisfire,
 	EnableDelayedWeaponActions,
 	EnableLegacyUpgradeSystem,
-	EnableLoadoutsForSpawnSupplies,
-	EnableCocStyleForLoadoutsSpawnSupplies,
 };
 
 enum class EEngineExternalRender 
@@ -116,6 +122,7 @@ public:
 	bool operator[](const EEngineExternalUI& ID) const;
 	bool operator[](const EEngineExternalPhysical& ID) const;
 	bool operator[](const EEngineExternalGame& ID) const;
+	bool operator[](const EEngineExternalSpawnSupplies& ID) const;
 	bool operator[](const EEngineExternalRender& ID) const;
 	bool operator[](const EEngineExternalEnvironment& ID) const;
 	bool operator[](const EEngineExternalPlatform& ID) const;

--- a/src/xrGame/alife_object.cpp
+++ b/src/xrGame/alife_object.cpp
@@ -198,21 +198,25 @@ void CSE_ALifeObject::spawn_supplies(LPCSTR ini_string)
 	);
 #pragma warning(pop)
 
-    const static bool isEnableLoadoutsForSpawnSupplies = EngineExternal()[EEngineExternalGame::EnableLoadoutsForSpawnSupplies];
-    const static bool isEnableCocStyleForLoadoutsSpawnSupplies = EngineExternal()[EEngineExternalGame::EnableCocStyleForLoadoutsSpawnSupplies];
+    processingVanillaSpawn(ini);
 
-    if (isEnableLoadoutsForSpawnSupplies) {
-        if (isEnableCocStyleForLoadoutsSpawnSupplies) 
-        {
-            processingSpawnOnceRandomItemInRandomLoadout(ini);
+    if (EngineExternal()[EEngineExternalSpawnSupplies::EnableLoadoutsSupplies]) {
+
+        if (EngineExternal()[EEngineExternalSpawnSupplies::EnableSpawnFullRandomLoadout]) {
+            processingSpawnFullRandomLoadout(ini);
+            return;
         }
-        else 
-        {
-            processingSpawnOnceFullRandomLoadout(ini);
+
+        if (EngineExternal()[EEngineExternalSpawnSupplies::EnableSpawnOnceRandomItemPerEachLoadouts]) {
+            processingSpawnOnceRandomItemPerEachLoadouts(ini);
+            return;
+        }
+
+        if (EngineExternal()[EEngineExternalSpawnSupplies::EnableSpawnOnceRandomitemByRandomLoadout]) {
+            processingSpawnOnceRandomitemByRandomLoadout(ini);
+            return;
         }
     }
-
-    processingVanillaSpawn(ini);
 }
 
 xr_vector <CInifile::Sect*> CSE_ALifeObject::parseLoadouts(CInifile& ini)
@@ -238,7 +242,7 @@ xr_vector <CInifile::Sect*> CSE_ALifeObject::parseLoadouts(CInifile& ini)
 }
 
 // Спавнит один полный лодаут среди случайных в рамках инклуда в профиле нпц в разделе supplies
-void CSE_ALifeObject::processingSpawnOnceFullRandomLoadout(CInifile& ini)
+void CSE_ALifeObject::processingSpawnFullRandomLoadout(CInifile& ini)
 {
     xr_vector <CInifile::Sect*> m_loadouts = parseLoadouts(ini);
     LPCSTR itemSection = "";
@@ -288,7 +292,7 @@ void CSE_ALifeObject::processingSpawnOnceFullRandomLoadout(CInifile& ini)
 }
 
 // Спавнит один случайный предмет среди случайно выбранного лодаута в рамках инклуда в профиле нпц в разделе supplies
-void CSE_ALifeObject::processingSpawnOnceRandomItemInRandomLoadout(CInifile& ini)
+void CSE_ALifeObject::processingSpawnOnceRandomitemByRandomLoadout(CInifile& ini)
 {
     xr_vector <CInifile::Sect*> m_loadouts = parseLoadouts(ini);
     if (m_loadouts.empty()) {
@@ -322,6 +326,52 @@ void CSE_ALifeObject::processingSpawnOnceRandomItemInRandomLoadout(CInifile& ini
         CSEItem,
         parseFloatParameterValue(spawnArgs, "cond=", 1.0f)
     );
+}
+
+// Спавнит по одному случайному предмету из каждого лодаута присутствующего у нпц в профиле в рамках 1 файла инклуда
+void CSE_ALifeObject::processingSpawnOnceRandomItemPerEachLoadouts(CInifile& ini)
+{
+    xr_vector <CInifile::Sect*> m_loadouts = parseLoadouts(ini);
+    LPCSTR itemSection = "";
+    LPCSTR spawnArgs = "";
+    size_t randomLoadoutItemIndex = 0;
+    size_t l_size = 0;
+
+    if (m_loadouts.empty()) {
+        return;
+    }
+
+    for (size_t il = 0; il < m_loadouts.size(); il++) {
+        l_size = m_loadouts[il]->Data.size();
+        if (l_size <= 0) {
+            continue;
+        }
+
+        randomLoadoutItemIndex = ::Random.randI(0, l_size);
+        itemSection = m_loadouts[il]->Data[randomLoadoutItemIndex].first.c_str();
+        spawnArgs = m_loadouts[il]->Data[randomLoadoutItemIndex].second.c_str();
+
+
+        if (pSettings->section_exist(itemSection))
+        {
+            CSE_Abstract* CSEItem = setAddonFlagsIsWeapon(
+                alife().spawn_item(itemSection, o_Position, m_tNodeID, m_tGraphID, ID),
+                spawnArgs
+            );
+
+            spawnAmmoForWeapon(
+                itemSection,
+                CSEItem,
+                parseIntParameterValue(spawnArgs, "ammo_type=", 0),
+                getCountValueToSpawn(spawnArgs)
+            );
+
+            setItemCondition(
+                CSEItem,
+                parseFloatParameterValue(spawnArgs, "cond=", 1.0f)
+            );
+        }
+    }
 }
 
 // Ванильный спавн

--- a/src/xrServerEntities/xrServer_Objects_ALife.h
+++ b/src/xrServerEntities/xrServer_Objects_ALife.h
@@ -165,8 +165,9 @@ private:
 	virtual void					spawnAmmoForWeapon(LPCSTR wpnSection, CSE_Abstract* E, int i_ammo_type, u32 countAmmoBoxesToSpawn);
 	virtual void					setItemCondition(CSE_Abstract* E, float condition);
 	virtual xr_vector <CInifile::Sect*> parseLoadouts(CInifile& ini);
-	virtual void					processingSpawnOnceFullRandomLoadout(CInifile& ini);
-	virtual void					processingSpawnOnceRandomItemInRandomLoadout(CInifile& ini);
+	virtual void					processingSpawnFullRandomLoadout(CInifile& ini);
+	virtual void					processingSpawnOnceRandomitemByRandomLoadout(CInifile& ini);
+	virtual void					processingSpawnOnceRandomItemPerEachLoadouts(CInifile& ini);
 	virtual void					processingVanillaSpawn(CInifile& ini);
 #endif
 


### PR DESCRIPTION
Переработаны лодауты (Восстановлен режим который должен был быть в CoC по умолчанию но не работал у нас)

Опции лодаутов в engine_external.ltx

EnableLoadoutsSupplies -- вкл выкл использование лодаутов у нпц

EnableSpawnFullRandomLoadout -- спавн всех секций одного случайного лодаута из файла у нпц

EnableSpawnOnceRandomItemPerEachLoadouts -- спавн по одному случайному предмету из всех лодаутов добавленных в нпц

EnableSpawnOnceRandomitemByRandomLoadout -- спавн одного случайного предмета среди всех лодаутов добавленных в нпц