### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/src/3rd-party/crypto/openssl/openssl/dh.h
+++ b/src/3rd-party/crypto/openssl/openssl/dh.h
@@ -154,6 +154,7 @@ struct dh_st
 /* DH_check_pub_key error codes */
 #define DH_CHECK_PUBKEY_TOO_SMALL	0x01
 #define DH_CHECK_PUBKEY_TOO_LARGE	0x02
+#define DH_CHECK_PUBKEY_INVALID         0x03
 
 /* primes p where (p-1)/2 is prime too are called "safe"; we define
    this for backward compatibility: */

--- a/src/3rd-party/crypto/openssl/src/dh_check.c
+++ b/src/3rd-party/crypto/openssl/src/dh_check.c
@@ -126,22 +126,38 @@ err:
 int DH_check_pub_key(const DH *dh, const BIGNUM *pub_key, int *ret)
 	{
 	int ok=0;
-	BIGNUM *q=NULL;
+	BIGNUM *tmp = NULL;
+    BN_CTX *ctx = NULL;
 
 	*ret=0;
-	q=BN_new();
-	if (q == NULL) goto err;
-	BN_set_word(q,1);
-	if (BN_cmp(pub_key,q) <= 0)
+	ctx = BN_CTX_new();
+    if (ctx == NULL) goto err;
+	BN_CTX_start(ctx);
+    tmp = BN_CTX_get(ctx);
+    if (tmp == NULL)
+        goto err;
+    BN_set_word(tmp, 1);
+    if (BN_cmp(pub_key, tmp) <= 0)
 		*ret|=DH_CHECK_PUBKEY_TOO_SMALL;
-	BN_copy(q,dh->p);
-	BN_sub_word(q,1);
-	if (BN_cmp(pub_key,q) >= 0)
+	BN_copy(tmp, dh->p);
+    BN_sub_word(tmp, 1);
+    if (BN_cmp(pub_key, tmp) >= 0)
 		*ret|=DH_CHECK_PUBKEY_TOO_LARGE;
+
+	if (dh->q != NULL) {
+        /* Check pub_key^q == 1 mod p */
+        if (!BN_mod_exp(tmp, pub_key, dh->q, dh->p, ctx))
+            goto err;
+        if (!BN_is_one(tmp))
+            *ret |= DH_CHECK_PUBKEY_INVALID;
+    }
 
 	ok = 1;
 err:
-	if (q != NULL) BN_free(q);
+	if (ctx != NULL) {
+        BN_CTX_end(ctx);
+        BN_CTX_free(ctx);
+    }
 	return(ok);
 	}
 


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in src/3rd-party/crypto/openssl/src/dh_check.c which was cloned from openssl/openssl but did not receive the security patch applied. The original issue was reported and fixed under https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2016-0701.

### Proposed Fix
Apply the same patch as the one in openssl/openssl to eliminate the vulnerability.

### Reference
https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2016-0701
https://github.com/openssl/openssl/commit/878e2c5b13010329c203f309ed0c8f2113f85648

### Proposed changes / Предлагаемые изменения

<!--
Please insert the list of changes below. For example:
Пожалуйста, вставьте список изменений ниже. Например:

- Added some functionality / Добавлена некоторая функциональность
- Deleted old things / Удалены старые вещи
- Fixed bug_name bug / Исправлен баг bug_name
-->

- 

### Associated issues / Ассоциированные проблемы

<!--
If this pull request is associated with any issue, then put its number here
please. For example:
Если этот запрос на извлечение связан с какой-либо проблемой, пожалуйста,
укажите его номер здесь. Например:

- #8
-->

- 

### Testing / Тестирование

<!--
Please write 'x' letter in '[]' to agree. For example:
Пожалуйста, напишите букву 'x' в '[]' для подтверждения. Например:

- [x] Manual testing / Ручное тестирование
-->

- [ ] Manual testing / Ручное тестирование

### Agreements / Согласия

- I agree to follow this project's [__Contributing Guidelines__](../CONTRIBUTING.md) /
Я согласен(-на) следовать [__Рекомендациям по внесению вклада в этот проект__](../CONTRIBUTING.rus.md)
- I agree to follow this project's [__Code of Conduct__](../CODE_OF_CONDUCT.md) /
Я согласен(-на) следовать [__Кодексу поведения этого проекта__](../CODE_OF_CONDUCT.rus.md)
