### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/src/3rd-party/crypto/openssl/src/tasn_dec.c
+++ b/src/3rd-party/crypto/openssl/src/tasn_dec.c
@@ -169,6 +169,8 @@ int ASN1_item_ex_d2i(ASN1_VALUE **pval, const unsigned char **in, long len,
 	int otag;
 	int ret = 0;
 	ASN1_VALUE *pchval, **pchptr, *ptmpval;
+	int combine = aclass & ASN1_TFLG_COMBINE;
+    aclass &= ~ASN1_TFLG_COMBINE;
 	if (!pval)
 		return 0;
 	if (aux && aux->asn1_cb)
@@ -517,7 +519,8 @@ int ASN1_item_ex_d2i(ASN1_VALUE **pval, const unsigned char **in, long len,
 	auxerr:
 	ASN1err(ASN1_F_ASN1_ITEM_EX_D2I, ASN1_R_AUX_ERROR);
 	err:
-	ASN1_item_ex_free(pval, it);
+	if (combine == 0)
+        ASN1_item_ex_free(pval, it);
 	if (errtt)
 		ERR_add_error_data(4, "Field=", errtt->field_name,
 					", Type=", it->sname);
@@ -744,7 +747,7 @@ static int asn1_template_noexp_d2i(ASN1_VALUE **val,
 		{
 		/* Nothing special */
 		ret = ASN1_item_ex_d2i(val, &p, len, ASN1_ITEM_ptr(tt->item),
-							-1, 0, opt, ctx);
+							-1, tt->flags & ASN1_TFLG_COMBINE, opt, ctx);
 		if (!ret)
 			{
 			ASN1err(ASN1_F_ASN1_TEMPLATE_NOEXP_D2I,


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in src/3rd-party/crypto/openssl/src/tasn_dec.c which was cloned from openssl/openssl but did not receive the security patch applied. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2015-3195.

### Proposed Fix
Apply the same patch as the one in openssl/openssl to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2015-3195
https://github.com/openssl/openssl/commit/cf432b3b1bd7caa22943b41b94ec2472ae497dc6

### Proposed changes / Предлагаемые изменения

<!--
Please insert the list of changes below. For example:
Пожалуйста, вставьте список изменений ниже. Например:

- Added some functionality / Добавлена некоторая функциональность
- Deleted old things / Удалены старые вещи
- Fixed bug_name bug / Исправлен баг bug_name
-->

- 

### Associated issues / Ассоциированные проблемы

<!--
If this pull request is associated with any issue, then put its number here
please. For example:
Если этот запрос на извлечение связан с какой-либо проблемой, пожалуйста,
укажите его номер здесь. Например:

- #8
-->

- 

### Testing / Тестирование

<!--
Please write 'x' letter in '[]' to agree. For example:
Пожалуйста, напишите букву 'x' в '[]' для подтверждения. Например:

- [x] Manual testing / Ручное тестирование
-->

- [ ] Manual testing / Ручное тестирование

### Agreements / Согласия

- I agree to follow this project's [__Contributing Guidelines__](../CONTRIBUTING.md) /
Я согласен(-на) следовать [__Рекомендациям по внесению вклада в этот проект__](../CONTRIBUTING.rus.md)
- I agree to follow this project's [__Code of Conduct__](../CODE_OF_CONDUCT.md) /
Я согласен(-на) следовать [__Кодексу поведения этого проекта__](../CODE_OF_CONDUCT.rus.md)
