### PR TITLE
fix bug crush on press delete save without selection

### DIFF
--- a/gamedata/scripts/ui_load_dialog.script
+++ b/gamedata/scripts/ui_load_dialog.script
@@ -228,11 +228,15 @@ end
 
 function load_dialog:OnMsgYes()
 	local index = self.list_box:GetSelectedIndex()
-
-	if index == -1 then return end
+	if index == -1 or index == 4294967295 then
+		return
+	end
 
 	if self.msgbox_id == 1 then
-		local item  = self.list_box:GetItemByIndex(index)
+		local item = self.list_box:GetItemByIndex(index)
+		if not item then
+			return
+		end
 
 		local fname = item.fn:GetText()
 
@@ -254,10 +258,14 @@ function load_dialog:load_game_internal()
 	if self.list_box:GetSize()==0 then return end
 
 	local index = self.list_box:GetSelectedIndex()
+	if index == -1 or index == 4294967295 then
+		return
+	end
 
-	if index == -1 then return end
-
-	local item  = self.list_box:GetItemByIndex(index)
+	local item = self.list_box:GetItemByIndex(index)
+	if not item then
+		return
+	end
 
 	local fname = item.fn:GetText()
 
@@ -313,10 +321,14 @@ end
 
 function load_dialog:OnButton_del_clicked()
 	if self.list_box:GetSize()==0 then return end
+	
 	local index = self.list_box:GetSelectedIndex()
-	local item = self.list_box:GetItemByIndex(index) -- Suhar_
-
-	if index == -1 or item==nil then -- Suhar_
+	if index == -1 or index == 4294967295 then
+		return
+	end
+	
+	local item = self.list_box:GetItemByIndex(index)
+	if not item then
 		return
 	end
 

--- a/src/xrUI/Widgets/UIListBox.cpp
+++ b/src/xrUI/Widgets/UIListBox.cpp
@@ -131,20 +131,22 @@ LPCSTR CUIListBox::GetSelectedText()
 u32 CUIListBox::GetSelectedIDX()
 {
 	u32 _idx = 0;
-	CUIWindow* w = GetSelected();
 
-	xrCriticalSectionGuard guard(m_pad->csUi);
-
-	for (CUIWindow* child : m_pad->GetChildWndList())
+	if (CUIWindow* w = GetSelected())
 	{
-		if (child->ui_cast_list_box_item() != nullptr)
-		{
-			if (child == w)
-			{
-				return _idx;
-			}
+		xrCriticalSectionGuard guard(m_pad->csUi);
 
-			++_idx;
+		for (CUIWindow* child : m_pad->GetChildWndList())
+		{
+			if (child->ui_cast_list_box_item() != nullptr)
+			{
+				if (child == w)
+				{
+					return _idx;
+				}
+
+				++_idx;
+			}
 		}
 	}
 


### PR DESCRIPTION
вылет если в меню загрузки игры не выбирая никакое сохранение нажать удалить и ок (упускается валидация index == -1) сменился тип отдаваемый с int на u32 поэтому некоторые скрипты имеют некоректную валидацию но нужно смотреть внимательно на класс от которого вызывали - ведь гении у пысс имеют дубликаты методов на каждый вид списков отдавая при этом разные данные то обьект то число и тд.