### PR TITLE
Ability to use 3d static instead of image drawing for encyclopedia article

### DIFF
--- a/gamedata/configs/ui/encyclopedia_item.xml
+++ b/gamedata/configs/ui/encyclopedia_item.xml
@@ -4,6 +4,7 @@
 	<encyclopedia_wnd>
 		<objective_item x="0" y="0" width="390" height="10">
 			<image x="170" y="0" width="5" height="5" stretch="1"/>
+			<model x="170" y="0" width="205" height="205" stretch="1"/>
 			
 			<text_cont x="0" y="90" width="390" height="10" complex_mode="1">
 				<text font="letterica18" r="255" g="255" b="255"/>

--- a/gamedata/configs/ui/encyclopedia_item_16.xml
+++ b/gamedata/configs/ui/encyclopedia_item_16.xml
@@ -4,7 +4,8 @@
 	<encyclopedia_wnd>
 		<objective_item x="0" y="0" width="303" height="10">
 			<image x="170" y="0" width="5" height="5" stretch="1"/>
-			
+			<model x="170" y="0" width="205" height="205" stretch="1"/>
+
 			<text_cont x="0" y="90" width="303" height="10" complex_mode="1">
 				<text font="letterica18" r="255" g="255" b="255"/>
 			</text_cont>

--- a/src/xrGame/encyclopedia_article.cpp
+++ b/src/xrGame/encyclopedia_article.cpp
@@ -35,8 +35,10 @@ CEncyclopediaArticle::CEncyclopediaArticle()
 
 CEncyclopediaArticle::~CEncyclopediaArticle()
 {
-	if( data()->image.GetParent() )
-		data()->image.GetParent()->DetachChild( &(data()->image) );
+	if (data()->image.GetParent())
+		data()->image.GetParent()->DetachChild(&(data()->image));
+	if (data()->model.GetParent())
+		data()->model.GetParent()->DetachChild(&(data()->model));
 }
 
 /*
@@ -71,75 +73,98 @@ void CEncyclopediaArticle::load_shared	(LPCSTR)
 	data()->group = pXML->ReadAttrib(pNode, "group", "");
 	//секция ltx, откуда читать данные
 	LPCSTR ltx = pXML->Read(pNode, "ltx", 0, nullptr);
+	LPCSTR model = pXML->Read(pNode, "model", 0, nullptr);
+	data()->model.SetVisual(nullptr);
 
-
-	if(ltx && pSettings->section_exist(ltx))
+	if (!model)
 	{
-		const char* icons_texture = READ_IF_EXISTS(pSettings, r_string, ltx, "icons_texture", nullptr);
-		data()->image.SetShader(InventoryUtilities::GetEquipmentIconsShader(icons_texture));
-
-		Frect tex_rect;
-		float scaleIcon = READ_IF_EXISTS(pSettings, r_float, ltx, "inv_scale", 1.0f);
-		tex_rect.x1 = float(pSettings->r_u32(ltx, "inv_grid_x") * INV_GRID_WIDTH(scaleIcon));
-		tex_rect.y1 = float(pSettings->r_u32(ltx, "inv_grid_y") * INV_GRID_HEIGHT(scaleIcon));
-		tex_rect.x2 = float(pSettings->r_u32(ltx, "inv_grid_width") * INV_GRID_WIDTH(scaleIcon));
-		tex_rect.y2 = float(pSettings->r_u32(ltx, "inv_grid_height") * INV_GRID_HEIGHT(scaleIcon));
-		tex_rect.rb.add(tex_rect.lt);
-		data()->image.GetUIStaticItem().SetTextureRect(tex_rect);
-	}
-	else 
-	{
-		if (ltx)
-			Msg("! Trying to read data from section [%s] for article [%s], but it doesn't exist!", ltx, m_ArticleId.c_str());
-
-		if( pXML->NavigateToNode(pNode,"texture",0) )
+		if (ltx && pSettings->section_exist(ltx))
 		{
-			pXML->SetLocalRoot(pNode);
-			CUIXmlInit::InitTexture(*pXML, "", 0, &data()->image);
-			pXML->SetLocalRoot(pXML->GetRoot());
+			const char* icons_texture = READ_IF_EXISTS(pSettings, r_string, ltx, "icons_texture", nullptr);
+			data()->image.SetShader(InventoryUtilities::GetEquipmentIconsShader(icons_texture));
+
+			Frect tex_rect;
+			float scaleIcon = READ_IF_EXISTS(pSettings, r_float, ltx, "inv_scale", 1.0f);
+			tex_rect.x1 = float(pSettings->r_u32(ltx, "inv_grid_x") * INV_GRID_WIDTH(scaleIcon));
+			tex_rect.y1 = float(pSettings->r_u32(ltx, "inv_grid_y") * INV_GRID_HEIGHT(scaleIcon));
+			tex_rect.x2 = float(pSettings->r_u32(ltx, "inv_grid_width") * INV_GRID_WIDTH(scaleIcon));
+			tex_rect.y2 = float(pSettings->r_u32(ltx, "inv_grid_height") * INV_GRID_HEIGHT(scaleIcon));
+			tex_rect.rb.add(tex_rect.lt);
+			data()->image.GetUIStaticItem().SetTextureRect(tex_rect);
+		}
+		else
+		{
+			if (ltx)
+				Msg("! Trying to read data from section [%s] for article [%s], but it doesn't exist!", ltx, m_ArticleId.c_str());
+
+			if (pXML->NavigateToNode(pNode, "texture", 0))
+			{
+				pXML->SetLocalRoot(pNode);
+				CUIXmlInit::InitTexture(*pXML, "", 0, &data()->image);
+				pXML->SetLocalRoot(pXML->GetRoot());
+			}
+		}
+
+		if (data()->image.GetShader() && data()->image.GetShader()->inited())
+		{
+			Frect r = data()->image.GetUIStaticItem().GetTextureRect();
+			data()->image.SetAutoDelete(false);
+
+			const int minSize = 65;
+
+			// Сначала устанавливаем если надо минимально допустимые размеры иконки
+			if (r.width() < minSize)
+			{
+				float dx = minSize - r.width();
+				r.x2 += dx;
+				data()->image.SetTextureOffset(dx / 2, data()->image.GetTextureOffeset()[1]);
+			}
+
+			if (r.height() < minSize)
+			{
+				float dy = minSize - r.height();
+				r.y2 += dy;
+				data()->image.SetTextureOffset(data()->image.GetTextureOffeset()[0], dy / 2);
+			}
+
+			data()->image.SetWndRect(Frect().set(0, 0, r.width(), r.height()));
 		}
 	}
-
-	if(data()->image.GetShader() && data()->image.GetShader()->inited())
+	else if (model)
 	{
-		Frect r = data()->image.GetUIStaticItem().GetTextureRect();
-		data()->image.SetAutoDelete(false);
-
-		const int minSize = 65;
-
-		// Сначала устанавливаем если надо минимально допустимые размеры иконки
-		if (r.width() < minSize)
-		{
-			float dx = minSize - r.width();
-			r.x2 += dx;
-			data()->image.SetTextureOffset(dx / 2, data()->image.GetTextureOffeset()[1]);
-		}
-
-		if (r.height() < minSize)
-		{
-			float dy = minSize - r.height();
-			r.y2 += dy;
-			data()->image.SetTextureOffset(data()->image.GetTextureOffeset()[0], dy / 2);
-		}
-
-		data()->image.SetWndRect(Frect().set(0,0,r.width(),r.height()));
-	};
+		bool bUseModelLtx				= pXML->ReadAttribBool(pNode, "model", 0, "use_ltx_model", true);
+		LPCSTR base_visual				= bUseModelLtx ? pSettings->r_string(model, "visual") : "";
+		IRenderVisual* iVis				= bUseModelLtx ? Render->model_Create(READ_IF_EXISTS(pSettings, r_string, model, "3d_static_visual_name", base_visual)) : Render->model_Create(model);
+		float rot_x						= deg2rad(pXML->ReadAttribFlt(pNode, "model", 0, "x", 0.f));
+		float rot_y						= deg2rad(pXML->ReadAttribFlt(pNode, "model", 0, "y", 0.f));
+		float rot_z						= deg2rad(pXML->ReadAttribFlt(pNode, "model", 0, "z", 0.f));
+		float scale						= pXML->ReadAttribFlt(pNode, "model", 0, "scale", 1.f);
+		data()->model.SetXYZ			(rot_x, rot_y, rot_z);
+		data()->model.SetVisual			(iVis);
+		data()->model.SetScaleFactor	(scale);
+	}
 
 	// Тип статьи
 	xr_string atricle_type = pXML->ReadAttrib(pNode, "article_type", "encyclopedia");
-	if(0==_stricmp(atricle_type.c_str(),"encyclopedia")){
+	if (0 == _stricmp(atricle_type.c_str(), "encyclopedia"))
+	{
 		data()->articleType = ARTICLE_DATA::eEncyclopediaArticle;
-	}else
-	if(0==_stricmp(atricle_type.c_str(),"journal")){
+	}
+	else if (0 == _stricmp(atricle_type.c_str(), "journal"))
+	{
 		data()->articleType = ARTICLE_DATA::eJournalArticle;
-	}else
-	if(0==_stricmp(atricle_type.c_str(),"task")){
+	}
+	else if (0 == _stricmp(atricle_type.c_str(), "task"))
+	{
 		data()->articleType = ARTICLE_DATA::eTaskArticle;
-	}else
-	if(0==_stricmp(atricle_type.c_str(),"info")){
+	}
+	else if (0 == _stricmp(atricle_type.c_str(), "info"))
+	{
 		data()->articleType = ARTICLE_DATA::eInfoArticle;
-	}else{
-		Msg("incorrect article type definition for [%s]",*item_data.id);
+	}
+	else
+	{
+		Msg("incorrect article type definition for [%s]", *item_data.id);
 	}
 
 	data()->ui_template_name = pXML->ReadAttrib(pNode, "ui_template", "common");

--- a/src/xrGame/encyclopedia_article.h
+++ b/src/xrGame/encyclopedia_article.h
@@ -10,6 +10,7 @@
 #include "shared_data.h"
 
 #include "../../xrUI/Widgets/UIStatic.h"
+#include "../../xrUI/Widgets/UI3dStatic.h"
 
 //////////////////////////////////////////////////////////////////////////
 // SInfoPortionData: данные для InfoProtion
@@ -20,7 +21,8 @@ struct SArticleData : CSharedResource
 	shared_str group;
 	
 	//картинка
-	CUIStatic image;
+	CUI3dStatic model;
+	CUIStatic	image;
 
 	//текст статьи
 	xr_string	text;

--- a/src/xrGame/inventory_item.cpp
+++ b/src/xrGame/inventory_item.cpp
@@ -175,6 +175,7 @@ void CInventoryItem::Load(LPCSTR section)
 	m_inv_rect.set(inv_grid_x, inv_grid_y, inv_grid_width, inv_grid_height);
 
 	ReadCustomTextAndMarks(section);
+	Read3dStaticsData(section);
 }
 
 void CInventoryItem::SetAdditionalDescription(LPCSTR additionalDescription)
@@ -214,6 +215,32 @@ void CInventoryItem::ReadCustomTextAndMarks(LPCSTR section)
 	m_custom_mark_size = READ_IF_EXISTS(pSettings, r_fvector2, section, "item_custom_mark_size", Fvector2().set(0.f, 0.f));
 	m_custom_mark_clr = READ_IF_EXISTS(pSettings, r_color, section, "item_custom_mark_clr", 0);
 }
+
+void CInventoryItem::Read3dStaticsData(LPCSTR section)
+{
+	// this functional will used for cell icons
+	m_3d_static_rotate_x		= deg2rad(READ_IF_EXISTS(pSettings, r_float, section, "3d_static_rotate_x", 0.f));
+	m_3d_static_rotate_y		= deg2rad(READ_IF_EXISTS(pSettings, r_float, section, "3d_static_rotate_y", 0.f));
+	m_3d_static_rotate_z		= deg2rad(READ_IF_EXISTS(pSettings, r_float, section, "3d_static_rotate_z", 0.f));
+	m_3d_static_scale			= READ_IF_EXISTS(pSettings, r_float, section, "3d_static_scale", 1.f);
+	m_3d_static_visual_name		= READ_IF_EXISTS(pSettings, r_string, section, "3d_static_visual_name", object().cNameVisual().c_str());
+
+	string_path vis_name;
+	if (pSettings->line_exist(section, "3d_static_visual_name"))
+	{
+		// Add default ext if no ext at all
+		if (0 == strext(m_3d_static_visual_name))
+			xr_strconcat(vis_name, vis_name, m_3d_static_visual_name, ".ogf");
+		else
+			xr_strcpy(vis_name, sizeof(vis_name), m_3d_static_visual_name);
+		if (!FS.exist("$game_meshes$", vis_name))
+		{
+			Msg("!Can't find model file '%s' declared 3d_static_visual_name line in [%s] section , fallback to common visual", vis_name, section);
+			m_3d_static_visual_name = object().cNameVisual().c_str();
+		}
+	}
+}
+
 
 void CInventoryItem::RefreshTranslations()
 {

--- a/src/xrGame/inventory_item.h
+++ b/src/xrGame/inventory_item.h
@@ -109,6 +109,7 @@ public:
 public:
 	virtual void Load(LPCSTR section);
 	void ReadCustomTextAndMarks(LPCSTR section);
+	void Read3dStaticsData(LPCSTR section);
 	void RefreshTranslations();
 
 	// Дополнение описания предмета для кастомизации через скрипты к основному описанию в UIItemInfo.cpp
@@ -171,6 +172,15 @@ public:
 	virtual float Weight() const { return m_weight; }
 	void setWeight(float value);
 
+	Fvector		Get3DStaticRotate() const
+	{
+		Fvector value;
+		value.x = m_3d_static_rotate_x;
+		value.y = m_3d_static_rotate_y;
+		value.z = m_3d_static_rotate_z;
+		return value;
+	}
+
 public:
 	CInventory* m_pInventory = nullptr;
 	shared_str m_section_id;
@@ -192,6 +202,10 @@ public:
 	LPCSTR m_custom_mark_lanim = {};
 	float ScaleIcon = 1.0f;
 	shared_str IconsTexture;
+
+	float m_3d_static_rotate_x, m_3d_static_rotate_y, m_3d_static_rotate_z = 0.f;
+	float m_3d_static_scale = 1.f;
+	LPCSTR m_3d_static_visual_name = "";
 
 	SInvItemPlace m_ItemCurrPlace = {};
 	RStringVec m_HiglightRelatedItemSections = {}; // FFx0001 ++

--- a/src/xrGame/ui/UIEncyclopediaArticleWnd.cpp
+++ b/src/xrGame/ui/UIEncyclopediaArticleWnd.cpp
@@ -3,14 +3,21 @@
 #include "../../xrUI/Widgets/UIStatic.h"
 #include "../encyclopedia_article.h"
 #include "../../xrUI/UIXmlInit.h"
+#include "../../xrUI/UICursor.h"
 #include "../../xrEngine/string_table.h"
+#include "../../xrEngine/xr_input.h"
+#include "../../Layers/xrRender/xrRender_console.h"
 
-CUIEncyclopediaArticleWnd::CUIEncyclopediaArticleWnd	()
-:m_Article(nullptr)
+CUIEncyclopediaArticleWnd::CUIEncyclopediaArticleWnd()
 {
+	m_Article		= nullptr;
+	m_UIImage		= nullptr;
+	m_UIModel		= nullptr;
+	m_UIText		= nullptr;
+	m_bUsedModel	= false;
 }
 
-CUIEncyclopediaArticleWnd::~CUIEncyclopediaArticleWnd	()
+CUIEncyclopediaArticleWnd::~CUIEncyclopediaArticleWnd()
 {
 }
 
@@ -19,37 +26,63 @@ void CUIEncyclopediaArticleWnd::Init(LPCSTR xml_name, LPCSTR start_from)
 	CUIXml uiXml;
 	uiXml.Load(CONFIG_PATH, UI_PATH, xml_name);
 
-	CUIXmlInit				xml_init;
+	CUIXmlInit					xml_init;
 
-	string512				str;
+	string512					str;
 
-	strcpy_s				(str,sizeof(str),start_from);
-	xml_init.InitWindow		(uiXml,str,0,this);
+	strcpy_s					(str,sizeof(str),start_from);
+	xml_init.InitWindow			(uiXml,str,0,this);
 
-	xr_strconcat			(str,start_from,":image");
-	m_UIImage				= new CUIStatic();	m_UIImage->SetAutoDelete(true);
+	xr_strconcat				(str,start_from,":image");
+	m_UIImage					= new CUIStatic();
+	m_UIImage->SetAutoDelete	(true);
 	xml_init.InitStatic			(uiXml,str,0,m_UIImage);
-	AttachChild				(m_UIImage);
+	AttachChild					(m_UIImage);
 
-	xr_strconcat			(str,start_from,":text_cont");
-	m_UIText				= new CUIStatic();	m_UIText->SetAutoDelete(true);
-	xml_init.InitStatic		(uiXml,str,0,m_UIText);
-	AttachChild				(m_UIText);
+	xr_strconcat				(str,start_from,":model");
+	m_UIModel					= new CUI3dStatic();
+	m_UIModel->SetAutoDelete	(true);
+	xml_init.InitStatic			(uiXml,str,0, m_UIModel);
+	AttachChild					(m_UIModel);
+
+	xr_strconcat				(str,start_from,":text_cont");
+	m_UIText					= new CUIStatic();
+	m_UIText->SetAutoDelete		(true);
+	xml_init.InitStatic			(uiXml,str,0,m_UIText);
+	AttachChild					(m_UIText);
 }
 
 void CUIEncyclopediaArticleWnd::SetArticle(CEncyclopediaArticle* article)
 {
-	if( article->data()->image.GetShader() && article->data()->image.GetShader()->inited())
+	if (article->data()->model.GetVisual())
 	{
-		m_UIImage->SetShader			(article->data()->image.GetShader());
-		m_UIImage->SetTextureRect		(article->data()->image.GetStaticItem()->GetTextureRect());
-		m_UIImage->SetWndSize			(article->data()->image.GetWndSize());
-		m_UIImage->SetWidth				(m_UIImage->GetWidth() * UI().get_current_kx());
+		// draw only one, model of image
+		m_UIModel->SetShader			(article->data()->model.GetShader());
+		m_UIModel->SetVisual			(article->data()->model.GetVisual());
+		Fvector xyz						= article->data()->model.GetXYZ();
+		m_UIModel->SetXYZ				(xyz);
+		m_UIModel->SetScaleFactor		(article->data()->model.GetScaleFactor());
 
-		float img_x						= (GetWidth()-m_UIImage->GetWidth())/2.0f;
+		float img_x						= (GetWidth() - m_UIModel->GetWidth()) / 2.0f;
 		img_x							= std::max(0.0f, img_x);
-		m_UIImage->SetWndPos			(Fvector2().set(img_x, m_UIImage->GetWndPos().y));
-	};
+		m_UIModel->SetWndPos			(Fvector2().set(img_x, m_UIModel->GetWndPos().y));
+		m_bUsedModel					= true;
+	}
+	else
+	{
+		if (article->data()->image.GetShader() && article->data()->image.GetShader()->inited())
+		{
+			m_UIImage->SetShader		(article->data()->image.GetShader());
+			m_UIImage->SetTextureRect	(article->data()->image.GetStaticItem()->GetTextureRect());
+			m_UIImage->SetWndSize		(article->data()->image.GetWndSize());
+			m_UIImage->SetWidth			(m_UIImage->GetWidth() * UI().get_current_kx());
+
+			float img_x					= (GetWidth() - m_UIImage->GetWidth()) / 2.0f;
+			img_x						= std::max(0.0f, img_x);
+			m_UIImage->SetWndPos		(Fvector2().set(img_x, m_UIImage->GetWndPos().y));
+			m_bUsedModel				= false;
+		}
+	}
 	m_UIText->SetTextST					(article->data()->text.c_str());
 	m_UIText->AdjustHeightToText		();
 
@@ -58,8 +91,9 @@ void CUIEncyclopediaArticleWnd::SetArticle(CEncyclopediaArticle* article)
 
 void CUIEncyclopediaArticleWnd::AdjustLauout()
 {
-	m_UIText->SetWndPos					(Fvector2().set(m_UIText->GetWndPos().x, m_UIImage->GetWndPos().y + m_UIImage->GetHeight()));
-	SetHeight							(m_UIImage->GetWndPos().y + m_UIImage->GetHeight()+m_UIText->GetHeight());
+	CUIStatic* pic_or_model = m_bUsedModel ? m_UIModel : m_UIImage;
+	m_UIText->SetWndPos					(Fvector2().set(m_UIText->GetWndPos().x, pic_or_model->GetWndPos().y + pic_or_model->GetHeight()));
+	SetHeight							(pic_or_model->GetWndPos().y + pic_or_model->GetHeight() + m_UIText->GetHeight());
 }
 
 void CUIEncyclopediaArticleWnd::SetArticle(LPCSTR article)
@@ -67,4 +101,19 @@ void CUIEncyclopediaArticleWnd::SetArticle(LPCSTR article)
 	CEncyclopediaArticle				A;
 	A.Load								(article);
 	SetArticle							(&A);
+}
+
+extern ENGINE_API float devfloat1;
+bool CUIEncyclopediaArticleWnd::OnMouseAction(float x, float y, EUIMessages mouse_action)
+{
+	if (m_UIModel->CursorOverWindow() && pInput->iGetAsyncBtnState(0))
+	{
+		// need to fix input invertion on 180 degs rotate
+		Fvector xyz = m_UIModel->GetXYZ();
+		Fvector2 delta_pos = GetUICursor().GetCursorPositionDelta();
+		xyz.x += delta_pos.y / 150.f/*devfloat1*/; // seems like value dependences by game screen resolution, will try another solution
+		xyz.y += delta_pos.x / 150.f/*devfloat1*/;
+		m_UIModel->SetXYZ(xyz);
+	}
+	return inherited::OnMouseAction(x, y, mouse_action);
 }

--- a/src/xrGame/ui/UIEncyclopediaArticleWnd.h
+++ b/src/xrGame/ui/UIEncyclopediaArticleWnd.h
@@ -1,19 +1,22 @@
 #pragma once
 #include "../../xrUI/Widgets/UIWindow.h"
+#include "../../xrUI/Widgets/UI3dStatic.h"
 
 class CUIStatic;
 class CEncyclopediaArticle;
 
 class CUIEncyclopediaArticleWnd final :public CUIWindow
 {
-typedef	CUIWindow		inherited;
+typedef	CUIWindow inherited;
 
-CUIStatic*				m_UIImage;
-CUIStatic*				m_UIText;
-CEncyclopediaArticle*	m_Article;
+	CUIStatic*				m_UIImage;
+	CUI3dStatic*			m_UIModel;
+	CUIStatic*				m_UIText;
+	CEncyclopediaArticle*	m_Article;
+	bool					m_bUsedModel;
 
 protected:
-			void		AdjustLauout				();
+			void	AdjustLauout					();
 
 public:
 					CUIEncyclopediaArticleWnd		();
@@ -21,5 +24,6 @@ public:
 			void	Init							(LPCSTR xml_name, LPCSTR start_from);
 			void	SetArticle						(CEncyclopediaArticle*);
 			void	SetArticle						(LPCSTR);
-	virtual CUIWindow* ui_cast_window() { return this; }
+	virtual	bool	OnMouseAction					(float x, float y, EUIMessages mouse_action);
+	virtual CUIWindow* ui_cast_window				() { return this; }
 };

--- a/src/xrUI/Widgets/UI3dStatic.cpp
+++ b/src/xrUI/Widgets/UI3dStatic.cpp
@@ -13,178 +13,186 @@
 
 CUI3dStatic::CUI3dStatic()
 {
-    fViewportNear = 0.2f;
-    fViewportDist = 0.3f;
+	m_fViewportNear				= 0.2f;
+	m_fViewportDist				= 0.3f;
 
-    fViewportFOV = deg2rad(2.0f);
-    fViewportSize = fViewportNear * tanf(fViewportFOV * 0.5f);
+	m_fViewportFOV				= deg2rad(2.0f);
+	m_fViewportSize				= m_fViewportNear * tanf(m_fViewportFOV * 0.5f);
 
-    fViewportAspect = (float)Device.TargetHeight / (float)Device.TargetWidth;
+	m_fViewportAspect			= (float)Device.TargetHeight / (float)Device.TargetWidth;
 
-    mProject.build_projection(fViewportFOV, fViewportAspect, fViewportNear, 20.0f);
+	m_mProject.build_projection	(m_fViewportFOV, m_fViewportAspect, m_fViewportNear, 20.0f);
 
-    mView.build_camera_dir(Fidentity.c, Fidentity.k, Fidentity.j);
-    mInvView.invert(mView);
+	m_mView.build_camera_dir	(Fidentity.c, Fidentity.k, Fidentity.j);
+	m_mInvView.invert			(m_mView);
 
-    rotate_matrix.set(Fidentity);
-    ScaleFactor = 1.0f;
+	m_rot_matrix.set			(Fidentity);
+	m_fScaleFactor				= 1.0f;
 
-    SetVisual(NULL);
+	SetVisual					(nullptr);
 }
 
 CUI3dStatic::~CUI3dStatic()
 {
-    SetVisual(NULL);
+	SetVisual(nullptr);
 }
 
 void CUI3dStatic::FromScreenToItem(int x, int y, float& x_item, float& y_item)
 {
-    float halfwidth = UI_BASE_WIDTH * 0.5f;
-    float halfheight = UI_BASE_HEIGHT * 0.5f;
+	float halfwidth = UI_BASE_WIDTH * 0.5f;
+	float halfheight = UI_BASE_HEIGHT * 0.5f;
 
-    float size_y = fViewportSize;
-    float size_x = size_y / fViewportAspect;
+	float size_y = m_fViewportSize;
+	float size_x = size_y / m_fViewportAspect;
 
-    float r_pt = float(x - halfwidth) * size_x / (float)halfwidth;
-    float u_pt = float(halfheight - y) * size_y / (float)halfheight;
+	float r_pt = float(x - halfwidth) * size_x / (float)halfwidth;
+	float u_pt = float(halfheight - y) * size_y / (float)halfheight;
 
-    x_item = r_pt * fViewportDist / fViewportNear;
-    y_item = u_pt * fViewportDist / fViewportNear;
+	x_item = r_pt * m_fViewportDist / m_fViewportNear;
+	y_item = u_pt * m_fViewportDist / m_fViewportNear;
 }
 
 void CUI3dStatic::Draw()
 {
-    if (m_pCurrentItem)
-    {
-        Frect rect{};
-        GetAbsoluteRect(rect);
+	if (m_pCurrentItem)
+	{
+		Frect rect{};
+		GetAbsoluteRect(rect);
 
-        if (rect.x1 > UI_BASE_WIDTH || rect.x2 < 0 || rect.y1 > UI_BASE_HEIGHT || rect.y2 < 0)
-        {
-            return;
-        }
+		if (rect.x1 > UI_BASE_WIDTH || rect.x2 < 0 || rect.y1 > UI_BASE_HEIGHT || rect.y2 < 0)
+		{
+			return;
+		}
 
-        Fmatrix matrix = Fidentity;
-        Fmatrix translate_matrix = Fidentity;
+		Fmatrix matrix = Fidentity;
+		Fmatrix translate_matrix = Fidentity;
 
-        translate_matrix.c.sub(m_pCurrentItem->getVisData().sphere.P);
+		translate_matrix.c.sub(m_pCurrentItem->getVisData().sphere.P);
 
-        matrix.mulA_44(translate_matrix);
-        matrix.mulA_44(rotate_matrix);
+		matrix.mulA_44(translate_matrix);
+		matrix.mulA_44(m_rot_matrix);
 
-        float x1, y1, x2, y2;
+		float x1, y1, x2, y2;
 
-        m_pCurrentItem->dcast_PKinematics()->CalculateBones_Invalidate();
-        m_pCurrentItem->dcast_PKinematics()->CalculateBones(TRUE);
+		m_pCurrentItem->dcast_PKinematics()->CalculateBones_Invalidate();
+		m_pCurrentItem->dcast_PKinematics()->CalculateBones(TRUE);
 
-        FromScreenToItem(rect.left, rect.top, x1, y1);
-        FromScreenToItem(rect.right, rect.bottom, x2, y2);
+		FromScreenToItem(rect.left, rect.top, x1, y1);
+		FromScreenToItem(rect.right, rect.bottom, x2, y2);
 
-        Fvector2 normal_size; normal_size.set(x2 - x1, y1 - y2);
+		Fvector2 normal_size; normal_size.set(x2 - x1, y1 - y2);
 
-        Fbox mBox = m_pCurrentItem->getVisData().box;
-        mBox.xform(matrix);
+		Fbox mBox = m_pCurrentItem->getVisData().box;
+		mBox.xform(matrix);
 
-        Fvector2 item_size; item_size.set(mBox.max.x - mBox.min.x, mBox.max.y - mBox.min.y);
-        normal_size.div(item_size);
+		Fvector2 item_size; item_size.set(mBox.max.x - mBox.min.x, mBox.max.y - mBox.min.y);
+		normal_size.div(item_size);
 
-        float scale = 0.95f * std::min(std::abs(normal_size.x), std::abs(normal_size.y)) * ScaleFactor;
+		float scale = 0.95f * std::min(std::abs(normal_size.x), std::abs(normal_size.y)) * m_fScaleFactor;
 
-        static Fmatrix scale_matrix;
+		static Fmatrix scale_matrix;
 
-        scale_matrix.scale(scale, scale, scale);
-        matrix.mulA_44(scale_matrix);
+		scale_matrix.scale(scale, scale, scale);
+		matrix.mulA_44(scale_matrix);
 
-        float right_item_offset, up_item_offset;
+		float right_item_offset, up_item_offset;
 
-        FromScreenToItem(rect.left + GetWidth() * 0.5f, rect.top + GetHeight() * 0.5f, right_item_offset, up_item_offset);
+		FromScreenToItem(rect.left + GetWidth() * 0.5f, rect.top + GetHeight() * 0.5f, right_item_offset, up_item_offset);
 
-        translate_matrix.identity();
-        translate_matrix.translate(right_item_offset, up_item_offset, fViewportDist);
+		translate_matrix.identity();
+		translate_matrix.translate(right_item_offset, up_item_offset, m_fViewportDist);
 
-        matrix.mulA_44(translate_matrix);
-        matrix.mulA_44(mInvView);
+		matrix.mulA_44(translate_matrix);
+		matrix.mulA_44(m_mInvView);
 
-        Device.vCameraTop.set(Fidentity.j);
-        Device.vCameraRight.set(Fidentity.i);
-        Device.vCameraDirection.set(Fidentity.k);
+		Device.vCameraTop.set(Fidentity.j);
+		Device.vCameraRight.set(Fidentity.i);
+		Device.vCameraDirection.set(Fidentity.k);
 
-        Device.vCameraPosition.set(Fidentity.c);
+		Device.vCameraPosition.set(Fidentity.c);
 
-        Device.mView = mView;
-        Device.mProject = mProject;
+		Device.mView = m_mView;
+		Device.mProject = m_mProject;
 
-        Device.m_pRender->SetCacheXform(Device.mView, Device.mProject);
+		Device.m_pRender->SetCacheXform(Device.mView, Device.mProject);
 
-        UI().PushScissor(rect);
-        
-        ::Render->set_UI(true);
+		UI().PushScissor(rect);
+		
+		::Render->set_UI(true);
 
-        m_pCurrentItem->getVisData().marker = 0;
+		m_pCurrentItem->getVisData().marker = 0;
 
-        ::Render->set_Transform(&matrix);
-        ::Render->add_Visual(m_pCurrentItem, true);
+		::Render->set_Transform(&matrix);
+		::Render->add_Visual(m_pCurrentItem, true);
 
-        ::Render->set_UI(false);
-        ::Render->RenderUI();
+		::Render->set_UI(false);
+		::Render->RenderUI();
 
-        UI().PopScissor();
+		UI().PopScissor();
 
-        Device.vCameraPosition.set(Device.vCameraPosition_saved);
+		Device.vCameraPosition.set(Device.vCameraPosition_saved);
 
-        Device.mView = Device.mView_saved;
-        Device.mProject = Device.mProject_saved;
+		Device.mView = Device.mView_saved;
+		Device.mProject = Device.mProject_saved;
 
-        Device.m_pRender->SetCacheXform(Device.mView, Device.mProject);
+		Device.m_pRender->SetCacheXform(Device.mView, Device.mProject);
 
-        CUIWindow::Draw();
-        return;
-    }
-    
-    inherited::Draw ();
+		CUIWindow::Draw();
+		return;
+	}
+	
+	inherited::Draw ();
 }
 
 Fvector CUI3dStatic::GetXYZ() const
 {
-    static Fvector rotate_vector{};
-    rotate_matrix.getXYZ(rotate_vector);
+	static Fvector rotate_vector{};
+	m_rot_matrix.getXYZ(rotate_vector);
 
-    return rotate_vector;
+	return rotate_vector;
+}
+
+Fvector CUI3dStatic::GetHPB() const
+{
+	static Fvector rotate_vector{};
+	m_rot_matrix.getHPB(rotate_vector);
+
+	return rotate_vector;
 }
 
 void CUI3dStatic::SetVisual(IRenderVisual* pVisual)
 {
-    if (m_pCurrentItem) 
-    {
-        ::Render->model_Delete(m_pCurrentItem);
-        m_pCurrentItem = NULL;
-    }
+	if (m_pCurrentItem) 
+	{
+		::Render->model_Delete(m_pCurrentItem);
+		m_pCurrentItem = nullptr;
+	}
 
-    if (!pVisual) 
-    {
-        return;
-    }
+	if (!pVisual) 
+	{
+		return;
+	}
 
-    m_pCurrentItem = ::Render->model_Duplicate(pVisual);
-    
-    if (auto pK = m_pCurrentItem->dcast_PKinematics()) 
-    {
-        pK->LL_SetBonesVisible(pVisual->dcast_PKinematics()->LL_GetBonesVisible());
-    }
+	m_pCurrentItem = ::Render->model_Duplicate(pVisual);
+	
+	if (auto pK = m_pCurrentItem->dcast_PKinematics()) 
+	{
+		pK->LL_SetBonesVisible(pVisual->dcast_PKinematics()->LL_GetBonesVisible());
+	}
 
-    if (auto pKa = m_pCurrentItem->dcast_PKinematicsAnimated()) 
-    {
-        auto MotionID = pKa->ID_Cycle_Safe("idle");
+	if (auto pKa = m_pCurrentItem->dcast_PKinematicsAnimated()) 
+	{
+		auto MotionID = pKa->ID_Cycle_Safe("idle");
 
-        if (!MotionID)
-        {
-            MotionID.set(0, 0);
-        }
+		if (!MotionID)
+		{
+			MotionID.set(0, 0);
+		}
 
-        pKa->PlayCycle(MotionID, false);
-    }
+		pKa->PlayCycle(MotionID, false);
+	}
 
-    m_pCurrentItem->dcast_PKinematics()->CalculateBones_Invalidate();
-    m_pCurrentItem->dcast_PKinematics()->CalculateBones(TRUE);
+	m_pCurrentItem->dcast_PKinematics()->CalculateBones_Invalidate();
+	m_pCurrentItem->dcast_PKinematics()->CalculateBones(TRUE);
 }
 

--- a/src/xrUI/Widgets/UI3dStatic.h
+++ b/src/xrUI/Widgets/UI3dStatic.h
@@ -6,40 +6,40 @@ class IRenderVisual;
 class UI_API CUI3dStatic : 
     public CUIStatic
 {
-    typedef CUIStatic inherited;
+	typedef CUIStatic inherited;
 
 public:
 
-    CUI3dStatic();
-    virtual ~CUI3dStatic();
+					CUI3dStatic		();
+	virtual			~CUI3dStatic	();
 
-    IC void SetXYZ(Fvector& _xyz) 
-    {
-        rotate_matrix.setXYZ(_xyz);
-    }
+	IC void			SetXYZ			(Fvector& _xyz) { m_rot_matrix.setXYZ(_xyz); }
 
-    IC void SetXYZ(float x, float y, float z) 
-    {
-        rotate_matrix.setXYZ(x, y, z);
-    }
+	IC void			SetXYZ			(float x, float y, float z) { m_rot_matrix.setXYZ(x, y, z); }
+	IC void			SetHPB			(float h, float p, float b) { Fvector pos = m_rot_matrix.c; m_rot_matrix.setHPB(h, p, b); m_rot_matrix.c = pos; }
+	IC void			SetHPB			(Fvector& _hpb) { Fvector pos = m_rot_matrix.c; m_rot_matrix.setHPB(_hpb.x,_hpb.y, _hpb.z ); m_rot_matrix.c = pos; }
 
-    Fvector GetXYZ() const;
+	Fvector			GetXYZ			() const;
+	Fvector			GetHPB			() const;
 
-    void SetVisual(IRenderVisual* pVisual);
-    virtual void Draw();
+			void	SetVisual		(IRenderVisual* pVisual);
+	virtual void	Draw			();
+			void	SetScaleFactor	(float fScale) { m_fScaleFactor = fScale; }
+			float	GetScaleFactor	() { return m_fScaleFactor;  }
 
-    float ScaleFactor = 1.0f;
-
+	IRenderVisual*	GetVisual		() { return m_pCurrentItem; }
 protected:
 
-    Fmatrix rotate_matrix = Fidentity;
+	Fmatrix m_rot_matrix = Fidentity;
 
-    void FromScreenToItem(int x_screen, int y_screen, float& x_item, float& y_item);
+	void FromScreenToItem				(int x_screen, int y_screen, float& x_item, float& y_item);
 
-    IRenderVisual* m_pCurrentItem = nullptr;
+	IRenderVisual* m_pCurrentItem = NULL;
 
-    float fViewportNear, fViewportDist, fViewportAspect;
-    float fViewportFOV, fViewportSize;
+	float m_fViewportNear, m_fViewportDist, m_fViewportAspect;
+	float m_fViewportFOV, m_fViewportSize;
 
-    Fmatrix mView, mInvView, mProject;
+	Fmatrix m_mView, m_mInvView, m_mProject;
+
+	float m_fScaleFactor;
 };


### PR DESCRIPTION
### Proposed changes / Предлагаемые изменения

<!--
Please insert the list of changes below. For example:
Пожалуйста, вставьте список изменений ниже. Например:

- Ability to use 3d static instead of image drawing for encyclopedia article / Возможность отрисовки модели в статьях энциклопедии вместо использования картинки
-->

There are examples of using this / Ниже приведены примеры использования данного функционала

```xml 
	<article id="article_model" name="article_model_name" group="tutorial">
		<text>article_model_desc</text>
		<!-- use_ltx_model="true" by default -->
		<model use_ltx_model="true" x="20" y="5" z="90" scale="0.5">grenade_f1</model>
	</article>
```

```xml 
	<article id="article_model" name="article_model_name" group="tutorial">
		<text>article_model_desc</text>
		<model use_ltx_model="false" x="20" y="5" z="90" scale="0.5">dynamics\weapons\wpn_grenades\wpn_f1.ogf</model>
	</article>
```


### Associated issues / Ассоциированные проблемы

Пока стоит вопрос в изменении поведения вращения модели, так как при повороте более чем на 180 градусов управление инвертируется. Также стоит заменить магическое число 150 на коэффициент, зависящий от разрешения экрана.

- 

### Testing / Тестирование


- [x] Manual testing / Ручное тестирование

### Agreements / Согласия

- I agree to follow this project's [__Contributing Guidelines__](../CONTRIBUTING.md) /
Я согласен(-на) следовать [__Рекомендациям по внесению вклада в этот проект__](../CONTRIBUTING.rus.md)
- I agree to follow this project's [__Code of Conduct__](../CODE_OF_CONDUCT.md) /
Я согласен(-на) следовать [__Кодексу поведения этого проекта__](../CODE_OF_CONDUCT.rus.md)
