### PR TITLE
Fix for incorrect display of characters in the control settings and console when running under Wine/Proton.

### DIFF
--- a/src/xrCore/appinfo.h
+++ b/src/xrCore/appinfo.h
@@ -4,6 +4,9 @@ class XRCORE_API CAppInfo
 {
 public:
 	SDL_Window* Window = nullptr;
+#ifdef IXR_WINDOWS
+	bool IsLaunchedViaWineOrProton = false;
+#endif
 
 	ThreadID MainThread = NULL;
 	ThreadID SecondaryThread = NULL;

--- a/src/xrCore/xrCore.cpp
+++ b/src/xrCore/xrCore.cpp
@@ -80,6 +80,10 @@ void xrCore::_initialize	(const char* _ApplicationName, xrLogger::LogCallback cb
 		g_uiExpressionMgr = new CExpressionManager();
 
 		g_Discord.Init();
+		
+#ifdef IXR_WINDOWS
+		g_AppInfo.IsLaunchedViaWineOrProton = std::getenv("WINELOADER") != nullptr;
+#endif
 	}
 
 	if (init_fs)

--- a/src/xrEngine/Xr_input.cpp
+++ b/src/xrEngine/Xr_input.cpp
@@ -311,6 +311,10 @@ bool CInput::get_dik_name(int dik, LPSTR dest_str, int dest_sz)
 	if (lang_locale != LANG_RUSSIAN) {
 		return false;
 	}
+
+	if (std::getenv("WINELOADER") != nullptr) {
+		return false;
+	}
 #endif
 
 	if (!russian_lookup_key_table.contains(dik)) {

--- a/src/xrEngine/Xr_input.cpp
+++ b/src/xrEngine/Xr_input.cpp
@@ -312,7 +312,8 @@ bool CInput::get_dik_name(int dik, LPSTR dest_str, int dest_sz)
 		return false;
 	}
 
-	if (std::getenv("WINELOADER") != nullptr) {
+	const char* WineLoader = std::getenv("WINELOADER");
+	if (WineLoader != nullptr) {
 		return false;
 	}
 #endif

--- a/src/xrEngine/Xr_input.cpp
+++ b/src/xrEngine/Xr_input.cpp
@@ -312,8 +312,7 @@ bool CInput::get_dik_name(int dik, LPSTR dest_str, int dest_sz)
 		return false;
 	}
 
-	const char* WineLoader = std::getenv("WINELOADER");
-	if (WineLoader != nullptr) {
+	if (g_AppInfo.IsLaunchedViaWineOrProton) {
 		return false;
 	}
 #endif


### PR DESCRIPTION
Due to the fact that the WinAPI GetKeyboardLayout function is not implemented in wine, the engine cannot correctly read the active keyboard layout, and it sets the Russian locale instead of the English locale by default. This commit fixes this issue in Wine/Proton (the WINELOADER environment variable is set in both Wine and Proton).

Before:
<img width="1926" height="1112" alt="Снимок экрана от 2026-06-09 12-18-31" src="https://github.com/user-attachments/assets/bcfb4011-e2ee-4e51-974c-648fdf35c682" />

After:
<img width="1926" height="1112" alt="Снимок экрана от 2026-06-09 12-20-24" src="https://github.com/user-attachments/assets/70f164d5-c19f-4f35-8d90-dde602f05213" />
