### PR TITLE
Исправлен баг связанный с DLTX для файлов из подкаталогов относительно MODNAME/configs

### DIFF
--- a/src/xrCore/Xr_ini.cpp
+++ b/src/xrCore/Xr_ini.cpp
@@ -1142,13 +1142,7 @@ void CInifile::LTXLoad(IReader* F, const char* path, xr_string_map<xr_string, Se
 		FS_FileSet ModFiles;
 		xr_string NormalizedFileName = FileName;
 		xr_strlwr(NormalizedFileName.data());
-
-		FS.file_list(
-			ModFiles,
-			FilePath.c_str(),
-			FS_ListFiles,
-			("mod_" + NormalizedFileName + "_*.ltx").c_str()
-		);
+		FS.file_list(ModFiles, FilePath.c_str(), FS_ListFiles, ("mod_" + NormalizedFileName + "_*.ltx").c_str());
 
 		auto GetRegexMatch = [](const xr_string& InputString, const xr_string& PatternString)->xr_string
 		{

--- a/src/xrCore/Xr_ini.cpp
+++ b/src/xrCore/Xr_ini.cpp
@@ -1140,7 +1140,15 @@ void CInifile::LTXLoad(IReader* F, const char* path, xr_string_map<xr_string, Se
 
 		// Collect all matching mod files
 		FS_FileSet ModFiles;
-		FS.file_list(ModFiles, FilePath.c_str(), FS_ListFiles, ("mod_" + FileName + "_*.ltx").c_str());
+		xr_string NormalizedFileName = FileName;
+		xr_strlwr(NormalizedFileName.data());
+
+		FS.file_list(
+			ModFiles,
+			FilePath.c_str(),
+			FS_ListFiles,
+			("mod_" + NormalizedFileName + "_*.ltx").c_str()
+		);
 
 		auto GetRegexMatch = [](const xr_string& InputString, const xr_string& PatternString)->xr_string
 		{


### PR DESCRIPTION
В процессе разработки аддона, который добавляет в Зов Припяти возможность лутать части монстров и продавать их торговцам, я заметил что не работает DLTX для файлов по типу "configs\creatures\mod_m_dog_mutants_parts.ltx" или "configs\misc\trade\mod_trade_zat_a2_barmen_mutants_parts.ltx". Данный PR исправляет это.