### PR TITLE
Поправил ЧЕРЕЗ НЕЙРОНКУ сглаживание при импорте ogf 

### DIFF
--- a/src/plugins/Maya/maya_import_tools.cxx
+++ b/src/plugins/Maya/maya_import_tools.cxx
@@ -2,6 +2,7 @@
 
 #define NOMINMAX
 #include <maya/MTypes.h>
+#include <cmath>
 
 #if MAYA_API_VERSION >= 20180000 && MAYA_API_VERSION <= 20190200
 #	include <MCppCompat.h>
@@ -35,6 +36,9 @@
 #include <maya/MPointArray.h>
 #include <maya/MProgressWindow.h>
 #include <maya/MSelectionList.h>
+#include <maya/MVector.h>
+#include <maya/MVectorArray.h>
+#include <maya/MFloatVectorArray.h>
 #include "maya_import_tools.h"
 #include "maya_progress.h"
 #include "xr_object.h"
@@ -73,6 +77,49 @@ static MString make_maya_name(const std::string& base, const char* old_suffix, c
 		return MString(base.c_str()) + suffix;
 	else
 		return MString(base.c_str(), int(pos & INT_MAX)) + suffix;
+}
+
+// X-Ray's compiled .ogf format does not preserve usable smoothing-group data.
+// The in-game renderer never reads sgroups at all - it uses the baked
+// per-corner vertex normals directly - so xrLC has no obligation to keep
+// sgroups meaningful, and the SDK's reconstruction of sgroups from those
+// normals is unreliable (can be empty, or non-empty but structured
+// differently than the original smoothing groups). That mismatch is
+// invisible in-game but produces partially/incorrectly faceted meshes in
+// Maya. We therefore ignore sgroups for OGF-derived meshes entirely and
+// recompute edge smoothing directly from the imported Maya geometry by
+// comparing adjacent face normals against an angle threshold (standard
+// "smooth by angle").
+static void smooth_by_angle(MObject& mesh_obj, double angle_degrees = 60.0)
+{
+	MFnMesh mesh_fn(mesh_obj);
+	int num_polygons = mesh_fn.numPolygons();
+	if (num_polygons == 0)
+		return;
+
+	MFloatVectorArray poly_normals(num_polygons);
+	for (MItMeshPolygon pit(mesh_obj); !pit.isDone(); pit.next()) {
+		MVector n;
+		pit.getNormal(n, MSpace::kObject);
+		poly_normals.set(MFloatVector(float(n.x), float(n.y), float(n.z)), pit.index());
+	}
+
+	double cos_threshold = cos(angle_degrees * 3.14159265358979323846 / 180.0);
+
+	MIntArray connected_faces;
+	for (MItMeshEdge eit(mesh_obj); !eit.isDone(); eit.next()) {
+		MStatus status;
+		eit.getConnectedFaces(connected_faces, &status);
+		if (!status || connected_faces.length() != 2) {
+			// border edges or non-manifold edges: leave hard
+			eit.setSmoothing(false);
+			continue;
+		}
+		const MFloatVector& n0 = poly_normals[connected_faces[0]];
+		const MFloatVector& n1 = poly_normals[connected_faces[1]];
+		double dot = double(n0.x)*n1.x + double(n0.y)*n1.y + double(n0.z)*n1.z;
+		eit.setSmoothing(dot >= cos_threshold);
+	}
 }
 
 MStatus maya_import_tools::import_object(const xr_object* object)
@@ -424,11 +471,42 @@ MStatus maya_import_tools::import_mesh(const xr_mesh* mesh, const xr_bone_vec& b
 	status = mesh_fn.assignUVs(poly_counts, uv_ids, 0);
 	CHECK_MSTATUS(status);
 
-	if (mesh->sgroups().empty()) {
-		for (MItMeshEdge it(mesh_obj); !it.isDone(); it.next())
-			it.setSmoothing(false);
+	if (!mesh->cnorm().empty()) {
+		// exact path: cnorm() holds the genuine per-corner normals as baked
+		// in the source file (.ogf/.dm) by the engine/compiler - the same
+		// vertex position can have different normals on different faces at
+		// a smoothing-group seam, so this must be set per face-vertex
+		// (setFaceVertexNormals), not per vertex (setVertexNormals), or
+		// faces sharing a seam vertex end up with a borrowed/wrong normal
+		// and render black.
+		const fvector3_vec& cn = mesh->cnorm();
+		unsigned num_corners = unsigned(cn.size() & UINT_MAX);
+		MVectorArray normals(num_corners);
+		MIntArray face_list(num_corners);
+		MIntArray vertex_list(num_corners);
+		unsigned corner = 0;
+		for (lw_face_vec_cit it = faces.begin(), end = faces.end(); it != end; ++it) {
+			int face_idx = int(it - faces.begin());
+			for (uint_fast32_t i = 0; i != 3; ++i, ++corner) {
+				const fvector3& n = cn[corner];
+				normals.set(MVector(n.x, n.y, -n.z), corner);
+				face_list.set(face_idx, corner);
+				vertex_list.set(int(it->v[i]), corner);
+			}
+		}
+		status = mesh_fn.setFaceVertexNormals(normals, face_list, vertex_list);
+		CHECK_MSTATUS(status);
+	} else if (!m_trust_sgroups || mesh->sgroups().empty()) {
+		// .ogf/.dm are compiled formats: the in-game renderer uses baked
+		// per-corner normals directly and never reads sgroups, so the SDK's
+		// reconstruction of sgroups for these formats is not guaranteed to
+		// match the original smoothing groups (and can be empty outright).
+		// Reconstruct smoothing from the actual imported geometry instead.
+		smooth_by_angle(mesh_obj);
 	} else {
-		
+		// .object source files store smoothing groups explicitly as authored
+		// in the editor/3ds Max/Maya export - this data is trustworthy, so
+		// use it as-is.
 		MIntArray connected;
 		const std::vector<uint32_t>& sgroups = mesh->sgroups();
 		if (m_target_sdk <= xray_re::SDK_VER_0_4) {
@@ -793,6 +871,7 @@ MStatus maya_import_tools::import_motions(const xr_skl_motion_vec& motions, MObj
 void maya_import_tools::set_default_options(void)
 {
 	m_target_sdk = xray_re::SDK_VER_DEFAULT;
+	m_trust_sgroups = true;
 }
 
 MStatus maya_import_tools::parse_options(const MString& options)
@@ -816,6 +895,10 @@ MStatus maya_import_tools::parse_options(const MString& options)
 		{
 			xray_re::sdk_version ver = xray_re::sdk_version_from_string(key_value[1].asChar());
 			m_target_sdk = (ver == xray_re::SDK_VER_UNKNOWN ? xray_re::SDK_VER_0_6 : ver);
+		}
+		else if (key_value[0] == "trust_sgroups")
+		{
+			m_trust_sgroups = (key_value[1] == "true");
 		}
 	}
 

--- a/src/plugins/Maya/maya_import_tools.h
+++ b/src/plugins/Maya/maya_import_tools.h
@@ -61,6 +61,8 @@ private:
 	maya_object_map	m_joints;
 
 	xray_re::sdk_version m_target_sdk;
+	bool		m_trust_sgroups;	// false for compiled formats (.ogf/.dm), where
+						// reconstructed smoothing groups are unreliable
 };
 
 #endif

--- a/src/plugins/Maya/maya_xray_tools.cxx
+++ b/src/plugins/Maya/maya_xray_tools.cxx
@@ -160,7 +160,7 @@ MStatus maya_dm_reader::reader(const MFileObject& file, const MString& options, 
 			dm->to_object();
 			advance_progress();
 			end_progress();
-			maya_import_tools(dm, &status);
+			maya_import_tools(dm, &status, "trust_sgroups=false");
 		} else {
 			msg("xray_re: can't open %s", path.asUTF8());
 			MGlobal::displayError(MString("xray_re: can't open ") + path);
@@ -301,7 +301,7 @@ MStatus maya_ogf_reader::reader(const MFileObject& file, const MString& options,
 			ogf->to_object();
 			advance_progress();
 			end_progress();
-			maya_import_tools(ogf, &status);
+			maya_import_tools(ogf, &status, "trust_sgroups=false");
 			delete ogf;
 		} else {
 			msg("xray_re: can't open %s", path.asUTF8());

--- a/src/plugins/PCore/xr_mesh.h
+++ b/src/plugins/PCore/xr_mesh.h
@@ -186,6 +186,16 @@ public:
 	fvector3_vec&					vnorm();
 	const fvector3_vec&				vnorm() const;
 
+	// per-corner (per-face-vertex) normals, exactly as stored in compiled
+	// formats (.ogf/.dm). Indexed as face_idx*3 + corner_idx (corner_idx
+	// 0/1/2 corresponds to v0/v1/v2 of that face in faces()). Unlike
+	// vnorm(), which holds a single normal per vertex position, this
+	// preserves the case where the same vertex position has different
+	// normals on different faces (smoothing-group seams) - needed to
+	// reproduce the original shading exactly rather than averaging it away.
+	fvector3_vec&					cnorm();
+	const fvector3_vec&				cnorm() const;
+
 	//fvector3_vec&					fnorm();
 	//const fvector3_vec&				fnorm() const;
 
@@ -205,7 +215,8 @@ protected:
 	xr_surfmap_vec				m_surfmaps;	// EMESH_CHUNK_SFACE
 	xr_vmap_vec					m_vmaps;	// EMESH_CHUNK_VMAPS
 
-	fvector3_vec				m_vertex_normals;	
+	fvector3_vec				m_vertex_normals;
+	fvector3_vec				m_corner_normals;	// optional; empty unless populated by the builder
 	//fvector3_vec				m_face_normals;
 };
 
@@ -261,6 +272,8 @@ inline const xr_vmap_vec& xr_mesh::vmaps() const { return m_vmaps; }
 
 inline fvector3_vec&			xr_mesh::vnorm() { return m_vertex_normals; }
 inline const fvector3_vec&		xr_mesh::vnorm() const { return m_vertex_normals; }
+inline fvector3_vec&			xr_mesh::cnorm() { return m_corner_normals; }
+inline const fvector3_vec&		xr_mesh::cnorm() const { return m_corner_normals; }
 //inline fvector3_vec&			xr_mesh::fnorm() { return m_face_normals; }
 //inline const fvector3_vec&	xr_mesh::fnorm() const { return m_face_normals; }
 } // end of namespace xray_re

--- a/src/plugins/PCore/xr_mesh_builder.cxx
+++ b/src/plugins/PCore/xr_mesh_builder.cxx
@@ -639,6 +639,28 @@ void xr_mesh_builder::commit(xr_object& object)
 	xr_raw_surface_vec().swap(m_raw_surfaces);
 
 	create_smoothing_groups();
+
+	// preserve the original per-corner normals (as authored/baked in the
+	// source OGF) into xr_mesh::cnorm() before they get discarded below.
+	// this is exact, not an approximation: OGF stores genuine per-corner
+	// normals (the same vertex position can carry different normals on
+	// different faces at a smoothing-group seam), and collapsing them to a
+	// single normal per vertex position (as vnorm() does) would be wrong
+	// for any vertex shared by faces from different smoothing groups.
+	// indexed as face_idx*3 + corner_idx, matching the face order about to
+	// be written into xr_mesh::m_faces below (corner_idx 0/1/2 <-> v0/v1/v2).
+	if (!m_normals.empty()) {
+		fvector3_vec& corner_normals = cnorm();
+		corner_normals.resize(m_faces.size() * 3);
+		uint32_t face_idx = 0;
+		for (b_face_vec_cit it = m_faces.begin(), end = m_faces.end();
+				it != end; ++it, ++face_idx) {
+			corner_normals[face_idx*3 + 0] = m_normals[it->n0];
+			corner_normals[face_idx*3 + 1] = m_normals[it->n1];
+			corner_normals[face_idx*3 + 2] = m_normals[it->n2];
+		}
+	}
+
 	std::vector<fvector3>().swap(m_normals);
 	b_edge_vec().swap(m_edges);
 	std::vector<uint32_t>().swap(m_vertex_edges);


### PR DESCRIPTION
<img width="2223" height="1100" alt="1" src="https://github.com/user-attachments/assets/0c8fbd33-d226-42a2-8011-aab57a701008" />
<img width="2090" height="1123" alt="2" src="https://github.com/user-attachments/assets/1eadd935-39d5-48ca-9bef-fa548acd2620" />
Сравнение сглаживания в плагине версии 2022 года и версии 2025 года. 
