### PR TITLE
Improved plugins

### DIFF
--- a/src/plugins/Maya/maya_export_tools.cxx
+++ b/src/plugins/Maya/maya_export_tools.cxx
@@ -369,7 +369,12 @@ static MStatus extract_weights(MFnMesh& mesh_fn, MFnSkinCluster& skin_fn,
 				int vert_idx = component_fn.element(j, &status);
 				CHECK_MSTATUS(status);
 				uint32_t weight_idx = weight_vmap->add_weight(float(weights[--k]), uint32_t(vert_idx & INT_MAX));
-				xr_assert(!weight_vmrefs[vert_idx].full());
+				if (weight_vmrefs[vert_idx].full()) {
+					msg("xray_re: vertex %d has too many bone influences (max 6). Reduce influences before exporting.", vert_idx);
+					MGlobal::displayError(MString("xray_re: vertex ") + vert_idx +
+						" has too many bone influences (max 6). Reduce influences before exporting.");
+					return MS::kFailure;
+				}
 				weight_vmrefs[vert_idx].push_back(lw_vmref_entry(vmap_idx, weight_idx));
 			}
 		}

--- a/src/plugins/Maya/maya_import_tools.cxx
+++ b/src/plugins/Maya/maya_import_tools.cxx
@@ -19,7 +19,9 @@
 #include <maya/MFnCharacter.h>
 #include <maya/MFnClip.h>
 #include <maya/MFnEnumAttribute.h>
+#include <maya/MFnDagNode.h>
 #include <maya/MFnIkJoint.h>
+#include <maya/MFnMatrixData.h>
 #include <maya/MFnMesh.h>
 #include <maya/MFnSet.h>
 #include <maya/MFnSingleIndexedComponent.h>
@@ -27,11 +29,14 @@
 #include <maya/MFnTransform.h>
 #include <maya/MGlobal.h>
 #include <maya/MIntArray.h>
+#include <maya/MObjectArray.h>
 #include <maya/MItDag.h>
 #include <maya/MItDependencyGraph.h>
 #include <maya/MItDependencyNodes.h>
 #include <maya/MItMeshEdge.h>
 #include <maya/MItMeshPolygon.h>
+#include <maya/MMatrix.h>
+#include <maya/MTransformationMatrix.h>
 #include <maya/MPlugArray.h>
 #include <maya/MPointArray.h>
 #include <maya/MProgressWindow.h>
@@ -67,6 +72,7 @@ maya_import_tools::maya_import_tools(const xray_re::xr_object* object, MStatus* 
 
 maya_import_tools::~maya_import_tools()
 {
+	delete m_replace_parent;
 	MGlobal::clearSelectionList();
 }
 
@@ -78,18 +84,6 @@ static MString make_maya_name(const std::string& base, const char* old_suffix, c
 	else
 		return MString(base.c_str(), int(pos & INT_MAX)) + suffix;
 }
-
-// X-Ray's compiled .ogf format does not preserve usable smoothing-group data.
-// The in-game renderer never reads sgroups at all - it uses the baked
-// per-corner vertex normals directly - so xrLC has no obligation to keep
-// sgroups meaningful, and the SDK's reconstruction of sgroups from those
-// normals is unreliable (can be empty, or non-empty but structured
-// differently than the original smoothing groups). That mismatch is
-// invisible in-game but produces partially/incorrectly faceted meshes in
-// Maya. We therefore ignore sgroups for OGF-derived meshes entirely and
-// recompute edge smoothing directly from the imported Maya geometry by
-// comparing adjacent face normals against an angle threshold (standard
-// "smooth by angle").
 static void smooth_by_angle(MObject& mesh_obj, double angle_degrees = 60.0)
 {
 	MFnMesh mesh_fn(mesh_obj);
@@ -127,16 +121,21 @@ MStatus maya_import_tools::import_object(const xr_object* object)
 	MStatus status = MS::kSuccess;
 	const xr_bone_vec& bones = object->bones();
 
-	start_progress(bones.size(), "Importing bones");
-	for (xr_bone_vec_cit it = bones.begin(), end = bones.end(); it != end; ++it) {
-		if ((*it)->is_root()) {
-			status = import_bone(*it, MObject::kNullObj);
-			break;
+	if (m_attach_to_selection) {
+		if (!(status = attach_to_selected_skeleton(bones)))
+			return status;
+	} else {
+		start_progress(bones.size(), "Importing bones");
+		for (xr_bone_vec_cit it = bones.begin(), end = bones.end(); it != end; ++it) {
+			if ((*it)->is_root()) {
+				status = import_bone(*it, MObject::kNullObj);
+				break;
+			}
 		}
+		end_progress();
+		if (!status)
+			return status;
 	}
-	end_progress();
-	if (!status)
-		return status;
 
 	maya_object_map shared_textures;
 	start_progress(object->surfaces().size(), "Importing surfaces");
@@ -158,18 +157,47 @@ MStatus maya_import_tools::import_object(const xr_object* object)
 		return status;
 	shared_textures.clear();
 
+	MObjectArray created_transforms;
+	bool single_mesh = object->meshes().size() == 1;
+
 	start_progress(object->meshes().size(), "Importing meshes");
 	for (xr_mesh_vec_cit it = object->meshes().begin(),
 			end = object->meshes().end(); it != end; ++it) {
-		if (!(status = import_mesh(*it, bones)))
+		MObject out_transform;
+		if (!(status = import_mesh(*it, bones, &out_transform)))
 			break;
+		if (!out_transform.isNull())
+			created_transforms.append(out_transform);
 		advance_progress();
 	}
 	end_progress();
 	if (!status)
 		return status;
 
-	if (!bones.empty()) {
+	if (m_attach_to_selection && single_mesh && created_transforms.length() == 1) {
+		MFnDagNode new_dag_fn(created_transforms[0]);
+		if (m_replace_parent) {
+			MFnDagNode(*m_replace_parent).addChild(created_transforms[0]);
+		}
+		if (!m_replace_name.empty())
+			new_dag_fn.setName(MString(m_replace_name.c_str()));
+	} else if (!m_attach_to_selection && created_transforms.length() == 1 && !m_group_name.empty()) {
+		MFnDagNode dag_fn(created_transforms[0]);
+		dag_fn.setName(MString(m_group_name.c_str()));
+	} else if (!m_attach_to_selection && created_transforms.length() > 1 && !m_group_name.empty()) {
+		MFnTransform group_fn;
+		MObject group_obj = group_fn.create(MObject::kNullObj, &status);
+		if (status) {
+			std::string safe_name = m_group_name;
+			if (!safe_name.empty() && std::isdigit((unsigned char)safe_name[0]))
+				safe_name = "_" + safe_name;
+			group_fn.setName(MString(safe_name.c_str()));
+			for (unsigned i = 0, n = created_transforms.length(); i != n; ++i)
+				group_fn.addChild(created_transforms[i]);
+		}
+	}
+
+	if (!bones.empty() && !m_attach_to_selection) {
 		MObject character_obj = create_character(&status);
 		if (status && !object->motions().empty()) {
 			reset_animation_state();
@@ -344,6 +372,27 @@ MStatus maya_import_tools::import_surface(const xr_surface* surface, MObject& te
 	return status;
 }
 
+static MMatrix compute_bind_world_matrix(const xr_bone* bone)
+{
+	const fvector3& t = bone->bind_offset();
+	double x = MDistance(t.x, MDistance::kMeters).asCentimeters();
+	double y = MDistance(t.y, MDistance::kMeters).asCentimeters();
+	double z = MDistance(t.z, MDistance::kMeters).asCentimeters();
+
+	const fvector3& r = bone->bind_rotate();
+	MEulerRotation euler(-r.x, -r.y, r.z, MEulerRotation::kZXY);
+
+	MTransformationMatrix local;
+	local.setTranslation(MVector(x, y, -z), MSpace::kTransform);
+	local.rotateTo(euler);
+
+	MMatrix local_matrix = local.asMatrix();
+	const xr_bone* parent = bone->parent();
+	if (parent == 0)
+		return local_matrix;
+	return local_matrix * compute_bind_world_matrix(parent);
+}
+
 MStatus maya_import_tools::import_bone(const xr_bone* bone, MObject& parent_obj)
 {
 	MStatus status;
@@ -389,7 +438,7 @@ static inline void append_uvs(const std::vector<fvector2>& uvs, MFloatArray& u_v
 	}
 }
 
-MStatus maya_import_tools::import_mesh(const xr_mesh* mesh, const xr_bone_vec& bones)
+MStatus maya_import_tools::import_mesh(const xr_mesh* mesh, const xr_bone_vec& bones, MObject* out_transform)
 {
 	MStatus status;
 
@@ -402,6 +451,8 @@ MStatus maya_import_tools::import_mesh(const xr_mesh* mesh, const xr_bone_vec& b
 		return status;
 	}
 	transform_fn.setName(make_maya_name(mesh->name(), "Shape"));
+	if (out_transform)
+		*out_transform = transform_obj;
 
 	const std::vector<fvector3>& points = mesh->points();
 	MPointArray vertices;
@@ -471,14 +522,9 @@ MStatus maya_import_tools::import_mesh(const xr_mesh* mesh, const xr_bone_vec& b
 	status = mesh_fn.assignUVs(poly_counts, uv_ids, 0);
 	CHECK_MSTATUS(status);
 
-	if (!mesh->cnorm().empty()) {
-		// exact path: cnorm() holds the genuine per-corner normals as baked
-		// in the source file (.ogf/.dm) by the engine/compiler - the same
-		// vertex position can have different normals on different faces at
-		// a smoothing-group seam, so this must be set per face-vertex
-		// (setFaceVertexNormals), not per vertex (setVertexNormals), or
-		// faces sharing a seam vertex end up with a borrowed/wrong normal
-		// and render black.
+	bool want_normals = (m_smoothing_mode == "soc" || m_smoothing_mode == "cscop") ? false : true;
+
+	if (want_normals && !mesh->cnorm().empty()) {
 		const fvector3_vec& cn = mesh->cnorm();
 		unsigned num_corners = unsigned(cn.size() & UINT_MAX);
 		MVectorArray normals(num_corners);
@@ -496,20 +542,12 @@ MStatus maya_import_tools::import_mesh(const xr_mesh* mesh, const xr_bone_vec& b
 		}
 		status = mesh_fn.setFaceVertexNormals(normals, face_list, vertex_list);
 		CHECK_MSTATUS(status);
-	} else if (!m_trust_sgroups || mesh->sgroups().empty()) {
-		// .ogf/.dm are compiled formats: the in-game renderer uses baked
-		// per-corner normals directly and never reads sgroups, so the SDK's
-		// reconstruction of sgroups for these formats is not guaranteed to
-		// match the original smoothing groups (and can be empty outright).
-		// Reconstruct smoothing from the actual imported geometry instead.
-		smooth_by_angle(mesh_obj);
-	} else {
-		// .object source files store smoothing groups explicitly as authored
-		// in the editor/3ds Max/Maya export - this data is trustworthy, so
-		// use it as-is.
+	} else if (!want_normals && !mesh->sgroups().empty()) {
+		// SoC vs CS/CoP sgroups encoding, picked explicitly rather than
+		// inferred from m_target_sdk.
 		MIntArray connected;
 		const std::vector<uint32_t>& sgroups = mesh->sgroups();
-		if (m_target_sdk <= xray_re::SDK_VER_0_4) {
+		if (m_smoothing_mode == "soc") {
 			if (mesh->flags() & EMF_3DSMAX) {
 				for (MItMeshEdge it(mesh_obj); !it.isDone(); it.next()) {
 					it.getConnectedFaces(connected, &status);
@@ -535,6 +573,8 @@ MStatus maya_import_tools::import_mesh(const xr_mesh* mesh, const xr_bone_vec& b
 				mesh_fn.setEdgeSmoothing(connected[2], !(sgroups[it.index()] & 0x4));
 			}
 		}
+	} else {
+		smooth_by_angle(mesh_obj);
 	}
 
 	MDagPath mesh_path;
@@ -579,7 +619,7 @@ MStatus maya_import_tools::import_mesh(const xr_mesh* mesh, const xr_bone_vec& b
 	}
 
 	if (!bones.empty()) {
-		MString command("skinCluster -mi 2 -tsb ");
+		MString command(m_attach_to_selection ? "skinCluster -mi 2 " : "skinCluster -mi 2 -tsb ");
 		for (maya_object_map_it it = m_joints.begin(), end = m_joints.end(); it != end; ++it) {
 			MFnIkJoint joint_fn(it->second, &status);
 			CHECK_MSTATUS(status);
@@ -604,6 +644,32 @@ MStatus maya_import_tools::import_mesh(const xr_mesh* mesh, const xr_bone_vec& b
 		MFnSkinCluster skin_fn(skin_obj, &status);
 		if (!status)
 			return status;
+
+		if (m_attach_to_selection) {
+			for (xr_bone_vec_cit it = bones.begin(), end = bones.end(); it != end; ++it) {
+				const xr_bone* bone = *it;
+				maya_object_map_it joint_it = m_joints.find(bone->name());
+				if (joint_it == m_joints.end())
+					continue;
+				MFnIkJoint joint_fn(joint_it->second, &status);
+				CHECK_MSTATUS(status);
+				MDagPath joint_path;
+				status = joint_fn.getPath(joint_path);
+				CHECK_MSTATUS(status);
+				unsigned influence_idx = skin_fn.indexForInfluenceObject(joint_path, &status);
+				CHECK_MSTATUS(status);
+
+				MMatrix bind_world = compute_bind_world_matrix(bone);
+				MPlug bpm_array_plug = skin_fn.findPlug("bindPreMatrix", true, &status);
+				CHECK_MSTATUS(status);
+				MPlug bpm_plug = bpm_array_plug.elementByLogicalIndex(influence_idx, &status);
+				CHECK_MSTATUS(status);
+				MFnMatrixData matrix_data;
+				MObject matrix_obj = matrix_data.create(bind_world.inverse());
+				status = bpm_plug.setValue(matrix_obj);
+				CHECK_MSTATUS(status);
+			}
+		}
 
 		MFnSingleIndexedComponent component_fn;
 		MObject component_obj = component_fn.create(MFn::kMeshVertComponent, &status);
@@ -658,6 +724,84 @@ MStatus maya_import_tools::import_mesh(const xr_mesh* mesh, const xr_bone_vec& b
 				influence_indices, vertex_weights, false);
 		CHECK_MSTATUS(status);
 	}
+	return MS::kSuccess;
+}
+
+MStatus maya_import_tools::attach_to_selected_skeleton(const xr_bone_vec& bones)
+{
+	MSelectionList selection_list;
+	MStatus status = MGlobal::getActiveSelectionList(selection_list);
+	if (selection_list.isEmpty()) {
+		MGlobal::displayError("xray_re: nothing is selected - select the rigged mesh "
+			"you want to replace");
+		return MS::kInvalidParameter;
+	}
+
+	MDagPath mesh_path;
+	status = selection_list.getDagPath(0, mesh_path);
+	if (!status || !mesh_path.hasFn(MFn::kTransform)) {
+		MGlobal::displayError("xray_re: selected object is not a mesh - select the "
+			"rigged mesh you want to replace");
+		return MS::kInvalidParameter;
+	}
+	MFnDagNode old_dag_fn(mesh_path);
+	MObject shape_obj = old_dag_fn.child(0, &status);
+	if (!status || !shape_obj.hasFn(MFn::kMesh)) {
+		MGlobal::displayError("xray_re: selected object is not a mesh - select the "
+			"rigged mesh you want to replace");
+		return MS::kInvalidParameter;
+	}
+
+	MItDependencyGraph skin_it(shape_obj, MFn::kSkinClusterFilter,
+		MItDependencyGraph::kUpstream, MItDependencyGraph::kBreadthFirst,
+		MItDependencyGraph::kNodeLevel, &status);
+	if (!status || skin_it.isDone()) {
+		MGlobal::displayError("xray_re: selected mesh has no skinCluster to take "
+			"the existing skeleton from");
+		return MS::kInvalidParameter;
+	}
+	MObject skin_obj = skin_it.currentItem();
+	MFnSkinCluster skin_fn(skin_obj, &status);
+	CHECK_MSTATUS(status);
+
+	MDagPathArray joints;
+	skin_fn.influenceObjects(joints, &status);
+	CHECK_MSTATUS(status);
+	for (unsigned i = 0, n = joints.length(); i != n; ++i) {
+		MFnIkJoint joint_fn(joints[i]);
+		MObject& stored = m_joints[joint_fn.name().asChar()];
+		if (stored.isNull())
+			stored = joints[i].node();
+	}
+
+	bool all_found = true;
+	for (xr_bone_vec_cit it = bones.begin(), end = bones.end(); it != end; ++it) {
+		const std::string& name = (*it)->name();
+		if (m_joints.find(name) == m_joints.end()) {
+			msg("xray_re: existing skeleton is missing bone %s", name.c_str());
+			MGlobal::displayError(MString("xray_re: existing skeleton is missing bone ") + name.c_str());
+			all_found = false;
+		}
+	}
+	if (!all_found) {
+		MGlobal::displayError("xray_re: selected mesh's skeleton does not match the "
+			"bones referenced by the new model - aborting replace");
+		return MS::kInvalidParameter;
+	}
+
+	m_replace_name = old_dag_fn.name().asChar();
+	MObject parent_obj = old_dag_fn.parent(0, &status);
+	delete m_replace_parent;
+	m_replace_parent = (status && !parent_obj.hasFn(MFn::kWorld)) ? new MObject(parent_obj) : 0;
+
+	MString old_mesh_path_name = mesh_path.fullPathName();
+	status = MGlobal::executeCommand(MString("delete \"") + old_mesh_path_name + "\"");
+	if (!status) {
+		msg("xray_re: failed to delete old mesh %s", old_mesh_path_name.asChar());
+		MGlobal::displayError(MString("xray_re: failed to delete old mesh ") + old_mesh_path_name);
+		return status;
+	}
+
 	return MS::kSuccess;
 }
 
@@ -871,7 +1015,11 @@ MStatus maya_import_tools::import_motions(const xr_skl_motion_vec& motions, MObj
 void maya_import_tools::set_default_options(void)
 {
 	m_target_sdk = xray_re::SDK_VER_DEFAULT;
-	m_trust_sgroups = true;
+	m_smoothing_mode = "normals";
+	m_attach_to_selection = false;
+	m_replace_name.clear();
+	m_replace_parent = 0;
+	m_group_name.clear();
 }
 
 MStatus maya_import_tools::parse_options(const MString& options)
@@ -896,9 +1044,17 @@ MStatus maya_import_tools::parse_options(const MString& options)
 			xray_re::sdk_version ver = xray_re::sdk_version_from_string(key_value[1].asChar());
 			m_target_sdk = (ver == xray_re::SDK_VER_UNKNOWN ? xray_re::SDK_VER_0_6 : ver);
 		}
-		else if (key_value[0] == "trust_sgroups")
+		else if (key_value[0] == "smoothing_mode")
 		{
-			m_trust_sgroups = (key_value[1] == "true");
+			m_smoothing_mode = key_value[1].asChar();
+		}
+		else if (key_value[0] == "attach_to_selection")
+		{
+			m_attach_to_selection = (key_value[1] == "true");
+		}
+		else if (key_value[0] == "group_name")
+		{
+			m_group_name = key_value[1].asChar();
 		}
 	}
 

--- a/src/plugins/Maya/maya_import_tools.h
+++ b/src/plugins/Maya/maya_import_tools.h
@@ -51,7 +51,9 @@ private:
 	MObject		create_character(MStatus* return_status = 0);
 	MStatus		import_surface(const xray_re::xr_surface* surface, MObject& texture_obj);
 	MStatus		import_bone(const xray_re::xr_bone* bone, MObject& parent_obj);
-	MStatus		import_mesh(const xray_re::xr_mesh* mesh, const std::vector<xray_re::xr_bone*>& bones);
+	MStatus		import_mesh(const xray_re::xr_mesh* mesh, const std::vector<xray_re::xr_bone*>& bones,
+					MObject* out_transform = 0);
+	MStatus		attach_to_selected_skeleton(const std::vector<xray_re::xr_bone*>& bones);
 
 	void		set_default_options(void);
 	MStatus		parse_options(const MString& options);
@@ -61,8 +63,15 @@ private:
 	maya_object_map	m_joints;
 
 	xray_re::sdk_version m_target_sdk;
-	bool		m_trust_sgroups;	// false for compiled formats (.ogf/.dm), where
-						// reconstructed smoothing groups are unreliable
+	std::string	m_smoothing_mode;	// "normals" (cnorm, exact - default), "soc",
+						// or "cscop" (explicit sgroups encoding choice)
+	bool		m_attach_to_selection;	// if true, skip creating new joints and instead
+						// skin onto an already-selected existing skeleton
+						// of matching bone names (mesh-swap workflow)
+	std::string	m_replace_name;		// name of the mesh being replaced (mesh-swap workflow)
+	MObject*	m_replace_parent;	// parent transform of the mesh being replaced, or null
+	std::string	m_group_name;		// source file base name; used to group multiple
+						// resulting meshes (e.g. after material/part splitting)
 };
 
 #endif

--- a/src/plugins/Maya/maya_xray_tools.cxx
+++ b/src/plugins/Maya/maya_xray_tools.cxx
@@ -8,6 +8,9 @@
 // i- X-Ray skeletal motions (.skls;*.skl)
 
 #define NOMINMAX
+#include <cstring>
+#include <algorithm>
+#include <map>
 #include <maya/MTypes.h>
 #if MAYA_API_VERSION >= 20180000 && MAYA_API_VERSION <= 20190200
 #include <maya/MCppCompat.h>
@@ -15,6 +18,17 @@
 #include <maya/MGlobal.h>
 #include <maya/MFnPlugin.h>
 #include <maya/MPxFileTranslator.h>
+#include <maya/MFnTransform.h>
+#include <maya/MFnAnimCurve.h>
+#include <maya/MFnDependencyNode.h>
+#include <maya/MEulerRotation.h>
+#include <maya/MDistance.h>
+#include <maya/MDGModifier.h>
+#include <maya/MTimeArray.h>
+#include <maya/MDoubleArray.h>
+#include <maya/MSelectionList.h>
+#include <maya/MDagPath.h>
+#include <maya/MPlug.h>
 #include "maya_import_tools.h"
 #include "maya_export_tools.h"
 #include "maya_xray_material.h"
@@ -23,9 +37,11 @@
 #include "xr_log.h"
 #include "xr_object.h"
 #include "xr_dm.h"
+#include "xr_string_utils.h"
 #include "xr_ogf.h"
 #include "xr_ogf_v4.h"
 #include "xr_skl_motion.h"
+#include "xr_obj_motion.h"
 #include "xr_object.h"
 #include "xr_sdk_version.h"
 
@@ -36,7 +52,8 @@ const char PLUGIN_VERSION[] = __DATE__;
 const char BUILD_DATE[] = __DATE__ " at " __TIME__;
 
 const MString dm_reader("X-Ray game detail object");
-const MString object_translator("X-Ray object");
+const MString object_reader("X-Ray object");
+const MString object_writer("X-Ray object");
 const MString skl_object_writer("X-Ray skeletal object");
 const MString ogf_reader("X-Ray game object");
 const MString omf_reader("X-Ray game skeletal motions");
@@ -56,15 +73,24 @@ public:
 	static void*		creator();
 };
 
-class maya_object_translator: public MPxFileTranslator {
+class maya_object_reader: public MPxFileTranslator {
 public:
 	virtual MStatus		reader(const MFileObject& file, const MString& options, FileAccessMode mode);
-	virtual MStatus		writer(const MFileObject& file, const MString& options, FileAccessMode mode);
 	virtual bool		haveReadMethod() const;
-	virtual bool		haveWriteMethod() const;
 	virtual MString		defaultExtension() const;
 	virtual MString		filter() const;
 	virtual bool		canBeOpened() const;
+	virtual MFileKind	identifyFile(const MFileObject& file, const char* buffer, short size) const;
+
+	static void*		creator();
+};
+
+class maya_object_writer: public MPxFileTranslator {
+public:
+	virtual MStatus		writer(const MFileObject& file, const MString& options, FileAccessMode mode);
+	virtual bool		haveWriteMethod() const;
+	virtual MString		defaultExtension() const;
+	virtual MString		filter() const;
 	virtual MFileKind	identifyFile(const MFileObject& file, const char* buffer, short size) const;
 
 	static void*		creator();
@@ -130,8 +156,11 @@ public:
 
 class maya_anm_writer: public MPxFileTranslator {
 public:
+	virtual MStatus		reader(const MFileObject& file, const MString& options, FileAccessMode mode);
 	virtual MStatus		writer(const MFileObject& file, const MString& options, FileAccessMode mode);
+	virtual bool		haveReadMethod() const;
 	virtual bool		haveWriteMethod() const;
+	virtual bool		canBeOpened() const;
 	virtual MString		defaultExtension() const;
 	virtual MString		filter() const;
 	virtual MFileKind	identifyFile(const MFileObject& file, const char *buffer, short size) const;
@@ -160,7 +189,7 @@ MStatus maya_dm_reader::reader(const MFileObject& file, const MString& options, 
 			dm->to_object();
 			advance_progress();
 			end_progress();
-			maya_import_tools(dm, &status, "trust_sgroups=false");
+			maya_import_tools(dm, &status, "smoothing_mode=normals");
 		} else {
 			msg("xray_re: can't open %s", path.asUTF8());
 			MGlobal::displayError(MString("xray_re: can't open ") + path);
@@ -186,7 +215,10 @@ MPxFileTranslator::MFileKind maya_dm_reader::identifyFile(const MFileObject& fil
 
 void* maya_dm_reader::creator() { return new maya_dm_reader; }
 
-MStatus maya_object_translator::reader(const MFileObject& file, const MString& options, FileAccessMode mode)
+// forward declaration: defined further below, used here by maya_object_reader::reader
+static void split_object_meshes_by_material(xr_object* object);
+
+MStatus maya_object_reader::reader(const MFileObject& file, const MString& options, FileAccessMode mode)
 {
 	
 
@@ -194,9 +226,25 @@ MStatus maya_object_translator::reader(const MFileObject& file, const MString& o
 	if (mode == kImportAccessMode || mode == kOpenAccessMode) {
 		const MString path = file.resolvedFullName();
 		xr_object* object = new xr_object;
-		if (object->load_object(path.asChar()))
-			maya_import_tools(object, &status, options);
-		else {
+		if (object->load_object(path.asChar())) {
+			object->calculate_bind();
+			bool replace_mode = strstr(options.asChar(), "attach_to_selection=true") != 0;
+			bool split_explicitly_disabled = strstr(options.asChar(), "split_parts=false") != 0;
+			if (!replace_mode && !split_explicitly_disabled)
+				split_object_meshes_by_material(object);
+
+			MString base_name = file.resolvedName();
+			int dot = base_name.rindex('.');
+			if (dot > 0)
+				base_name = base_name.substring(0, dot - 1);
+			MString combined_options = options;
+			if (combined_options.length())
+				combined_options += ";";
+			combined_options += "group_name=";
+			combined_options += base_name;
+
+			maya_import_tools(object, &status, combined_options);
+		} else {
 			msg("xray_re: can't open %s", path.asUTF8());
 			MGlobal::displayError(MString("xray_re: can't open ") + path);
 		}
@@ -205,7 +253,29 @@ MStatus maya_object_translator::reader(const MFileObject& file, const MString& o
 	return status;
 }
 
-MStatus maya_object_translator::writer(const MFileObject& file, const MString& options, FileAccessMode mode)
+bool maya_object_reader::haveReadMethod() const { return true; }
+
+MString maya_object_reader::defaultExtension() const { return MString("object"); }
+
+MString maya_object_reader::filter() const
+{
+#	if (MAYA_API_VERSION >= 201100) 
+		return MString("*.object");
+#	else
+		return MString("*.ob*");
+#	endif
+}
+
+bool maya_object_reader::canBeOpened() const { return true; }
+
+MPxFileTranslator::MFileKind maya_object_reader::identifyFile(const MFileObject& file, const char* buffer, short size) const
+{
+	return extract_extension(file) == defaultExtension() ? kIsMyFileType : kNotMyFileType;
+}
+
+void* maya_object_reader::creator() { return new maya_object_reader; }
+
+MStatus maya_object_writer::writer(const MFileObject& file, const MString& options, FileAccessMode mode)
 {
 	
 
@@ -224,13 +294,11 @@ MStatus maya_object_translator::writer(const MFileObject& file, const MString& o
 		mode == kExportActiveAccessMode);
 }
 
-bool maya_object_translator::haveReadMethod() const { return true; }
+bool maya_object_writer::haveWriteMethod() const { return true; }
 
-bool maya_object_translator::haveWriteMethod() const { return true; }
+MString maya_object_writer::defaultExtension() const { return MString("object"); }
 
-MString maya_object_translator::defaultExtension() const { return MString("object"); }
-
-MString maya_object_translator::filter() const
+MString maya_object_writer::filter() const
 {
 #	if (MAYA_API_VERSION >= 201100) 
 		return MString("*.object");
@@ -239,14 +307,12 @@ MString maya_object_translator::filter() const
 #	endif
 }
 
-bool maya_object_translator::canBeOpened() const { return true; }
-
-MPxFileTranslator::MFileKind maya_object_translator::identifyFile(const MFileObject& file, const char* buffer, short size) const
+MPxFileTranslator::MFileKind maya_object_writer::identifyFile(const MFileObject& file, const char* buffer, short size) const
 {
 	return extract_extension(file) == defaultExtension() ? kIsMyFileType : kNotMyFileType;
 }
 
-void* maya_object_translator::creator() { return new maya_object_translator; }
+void* maya_object_writer::creator() { return new maya_object_writer; }
 
 MStatus maya_skl_object_writer::writer(const MFileObject& file, const MString& options, FileAccessMode mode)
 {
@@ -287,6 +353,180 @@ MPxFileTranslator::MFileKind maya_skl_object_writer::identifyFile(const MFileObj
 
 void* maya_skl_object_writer::creator() { return new maya_skl_object_writer; }
 
+static xr_vmap* find_or_create_local_vmap(xr_vmap_vec& local_vmaps,
+		std::map<xr_vmap*, xr_vmap*>& vmap_remap, xr_vmap* src_vmap)
+{
+	std::map<xr_vmap*, xr_vmap*>::iterator it = vmap_remap.find(src_vmap);
+	if (it != vmap_remap.end())
+		return it->second;
+
+	unsigned dimension = (src_vmap->type() == xr_vmap::VMT_UV) ? 2 : 1;
+	xr_vmap* local_vmap = xr_vmap::create(src_vmap->name().c_str(), src_vmap->type(),
+		dimension, false);
+	local_vmaps.push_back(local_vmap);
+	vmap_remap[src_vmap] = local_vmap;
+	return local_vmap;
+}
+
+static void split_object_meshes_by_material(xr_object* object)
+{
+	xr_mesh_vec original_meshes = object->meshes();
+	object->meshes().clear();
+
+	for (xr_mesh_vec_it mit = original_meshes.begin(), mend = original_meshes.end();
+			mit != mend; ++mit) {
+		xr_mesh* src_mesh = *mit;
+		const xr_surfmap_vec& surfmaps = src_mesh->surfmaps();
+
+		if (surfmaps.size() <= 1) {
+			object->meshes().push_back(src_mesh);
+			continue;
+		}
+
+		const std::vector<fvector3>& src_points = src_mesh->points();
+		const lw_face_vec& src_faces = src_mesh->faces();
+		const lw_vmref_vec& src_vmrefs = src_mesh->vmrefs();
+		const xr_vmap_vec& src_vmaps = src_mesh->vmaps();
+		const fvector3_vec& src_vnorm = src_mesh->vnorm();
+		const fvector3_vec& src_cnorm = src_mesh->cnorm();
+
+		for (xr_surfmap_vec_cit sit = surfmaps.begin(), send = surfmaps.end();
+				sit != send; ++sit) {
+			const xr_surfmap* smap = *sit;
+			if (smap->faces.empty())
+				continue;
+
+			xr_mesh* part = new xr_mesh;
+			part->name() = smap->surface->name();
+			part->flags() = src_mesh->flags();
+
+			std::map<uint32_t, uint32_t> point_remap;	// src point idx -> local idx
+			std::map<xr_vmap*, xr_vmap*> vmap_remap;	// src vmap -> local vmap
+			xr_surfmap* local_smap = new xr_surfmap(smap->surface);
+
+			for (std::vector<uint32_t>::const_iterator fit = smap->faces.begin(),
+					fend = smap->faces.end(); fit != fend; ++fit) {
+				const lw_face& src_face = src_faces[*fit];
+				lw_face local_face;
+
+				for (uint_fast32_t i = 0; i != 3; ++i) {
+					uint32_t src_v = src_face.v[i];
+					std::map<uint32_t, uint32_t>::iterator pit = point_remap.find(src_v);
+					uint32_t local_v;
+					if (pit != point_remap.end()) {
+						local_v = pit->second;
+					} else {
+						local_v = uint32_t(part->points().size());
+						part->points().push_back(src_points[src_v]);
+						if (!src_vnorm.empty())
+							part->vnorm().push_back(src_vnorm[src_v]);
+						point_remap[src_v] = local_v;
+					}
+					local_face.v[i] = local_v;
+
+					if (!src_cnorm.empty()) {
+						uint32_t src_corner = uint32_t(*fit)*3 + i;
+						part->cnorm().push_back(src_cnorm[src_corner]);
+					}
+
+					const lw_vmref& src_ref = src_vmrefs[src_face.ref[i]];
+					lw_vmref local_ref;
+					for (lw_vmref::const_iterator rit = src_ref.begin(),
+							rend = src_ref.end(); rit != rend; ++rit) {
+						xr_vmap* src_vmap = src_vmaps[rit->vmap];
+						xr_vmap* local_vmap = find_or_create_local_vmap(
+							part->vmaps(), vmap_remap, src_vmap);
+						uint32_t local_offset;
+						if (src_vmap->type() == xr_vmap::VMT_UV) {
+							const xr_uv_vmap* src_uv = static_cast<const xr_uv_vmap*>(src_vmap);
+							local_offset = static_cast<xr_uv_vmap*>(local_vmap)->add_uv(
+								src_uv->uvs()[rit->offset], local_v);
+						} else {
+							const xr_weight_vmap* src_w = static_cast<const xr_weight_vmap*>(src_vmap);
+							local_offset = static_cast<xr_weight_vmap*>(local_vmap)->add_weight(
+								src_w->weights()[rit->offset], local_v);
+						}
+						uint32_t local_vmap_idx = uint32_t(std::find(part->vmaps().begin(),
+							part->vmaps().end(), local_vmap) - part->vmaps().begin());
+						local_ref.push_back(lw_vmref_entry(local_vmap_idx, local_offset));
+					}
+					part->vmrefs().push_back(local_ref);
+					local_face.ref[i] = uint32_t(part->vmrefs().size() - 1);
+				}
+				local_smap->faces.push_back(uint32_t(part->faces().size()));
+				part->faces().push_back(local_face);
+			}
+
+			part->surfmaps().push_back(local_smap);
+			part->calculate_bbox();
+			object->meshes().push_back(part);
+		}
+
+		delete src_mesh;
+	}
+}
+
+static void split_ogf_children(xr_ogf* ogf)
+{
+	if (!ogf->hierarchical() || ogf->children().empty())
+		return;
+
+	const xr_ogf_vec& children = ogf->children();
+
+	for (size_t i = 0, n = children.size(); i != n; ++i) {
+		xr_ogf* child = children[i];
+
+		if (child->hierarchical() && !child->children().empty()) {
+			split_ogf_children(child);
+			for (xr_mesh_vec_it mit = child->meshes().begin(),
+					mend = child->meshes().end(); mit != mend; ++mit) {
+				ogf->meshes().push_back(*mit);
+			}
+			child->meshes().clear();
+			for (xr_surface_vec_it sit = child->surfaces().begin(),
+					send = child->surfaces().end(); sit != send; ++sit) {
+				ogf->surfaces().push_back(*sit);
+			}
+			child->surfaces().clear();
+			continue;
+		}
+
+		child->bones() = ogf->bones();
+
+		child->to_object();
+		child->bones().clear();
+		if (child->meshes().empty())
+			continue;
+
+		xr_mesh* mesh = child->meshes().front();
+
+		std::string part_name;
+		if (!mesh->surfmaps().empty() && mesh->surfmaps().front()->surface)
+			part_name = mesh->surfmaps().front()->surface->name();
+		if (part_name.empty()) {
+			part_name = child->shader();
+			std::string::size_type pos = part_name.find_last_of("\\/");
+			if (pos != std::string::npos)
+				part_name = part_name.substr(pos + 1);
+		}
+		if (part_name.empty()) {
+			char buf[32];
+			xr_snprintf(buf, sizeof(buf), "part_%u", unsigned(i));
+			part_name = buf;
+		}
+		mesh->name() = part_name;
+
+		ogf->meshes().push_back(mesh);
+		child->meshes().clear();	
+
+		for (xr_surface_vec_it sit = child->surfaces().begin(),
+				send = child->surfaces().end(); sit != send; ++sit) {
+			ogf->surfaces().push_back(*sit);
+		}
+		child->surfaces().clear();
+	}
+}
+
 MStatus maya_ogf_reader::reader(const MFileObject& file, const MString& options, FileAccessMode mode)
 {
 	
@@ -298,10 +538,35 @@ MStatus maya_ogf_reader::reader(const MFileObject& file, const MString& options,
 		xr_ogf* ogf = xr_ogf::load_ogf(path.asChar());
 		if (ogf) {
 			advance_progress();
-			ogf->to_object();
+			ogf->calculate_bind();
+			bool replace_mode = strstr(options.asChar(), "attach_to_selection=true") != 0;
+			bool split_explicitly_disabled = strstr(options.asChar(), "split_parts=false") != 0;
+			if (!replace_mode && !split_explicitly_disabled && ogf->hierarchical() && !ogf->children().empty())
+				split_ogf_children(ogf);
+			else
+				ogf->to_object();
 			advance_progress();
 			end_progress();
-			maya_import_tools(ogf, &status, "trust_sgroups=false");
+			MString smoothing_mode = "normals";
+			const char* sm = strstr(options.asChar(), "smoothing_mode=");
+			if (sm) {
+				sm += strlen("smoothing_mode=");
+				const char* end = strchr(sm, ';');
+				smoothing_mode = end ? MString(sm, int(end - sm)) : MString(sm);
+			}
+			MString combined_options("smoothing_mode=");
+			combined_options += smoothing_mode;
+			if (replace_mode)
+				combined_options += ";attach_to_selection=true";
+
+			MString base_name = file.resolvedName();
+			int dot = base_name.rindex('.');
+			if (dot > 0)
+				base_name = base_name.substring(0, dot - 1);
+			combined_options += ";group_name=";
+			combined_options += base_name;
+
+			maya_import_tools(ogf, &status, combined_options);
 			delete ogf;
 		} else {
 			msg("xray_re: can't open %s", path.asUTF8());
@@ -470,6 +735,103 @@ MPxFileTranslator::MFileKind maya_skls_reader::identifyFile(const MFileObject& f
 
 void* maya_skls_reader::creator() { return new maya_skls_reader; }
 
+// exact copy of the helper of the same name in maya_import_tools.cxx (static,
+// file-local scope there, so it isn't visible from this translation unit).
+static inline void append_key(MTimeArray& times, MDoubleArray& values, double time, double value)
+{
+	unsigned size = values.length();
+	if (size == 0 || values[size-1] != value) {
+		times.append(MTime(time, MTime::kSeconds));
+		values.append(value);
+	}
+}
+
+MStatus maya_anm_writer::reader(const MFileObject& file, const MString& options, FileAccessMode mode)
+{
+	MStatus status = MS::kFailure;
+	if (mode != kImportAccessMode && mode != kOpenAccessMode)
+		return status;
+
+	MSelectionList s_list;
+	MGlobal::getActiveSelectionList(s_list);
+	if (s_list.length() != 1) {
+		msg("xray_re: select exactly one object to apply the .anm to");
+		MGlobal::displayError("xray_re: select exactly one object to apply the .anm to");
+		return status;
+	}
+
+	MDagPath dp;
+	status = s_list.getDagPath(0, dp);
+	if (!status) {
+		msg("xray_re: selected object has no transform");
+		MGlobal::displayError("xray_re: selected object has no transform");
+		return status;
+	}
+	MFnTransform transform_fn(dp, &status);
+	CHECK_MSTATUS_AND_RETURN_IT(status);
+
+	const MString path = file.resolvedFullName();
+	xr_obj_motion anm;
+	if (!anm.load_anm(path.asChar())) {
+		msg("xray_re: can't open %s", path.asUTF8());
+		MGlobal::displayError(MString("xray_re: can't open ") + path);
+		return MS::kFailure;
+	}
+
+	double fps = anm.fps();
+	if (fps <= 0.0)
+		fps = 30.0;
+
+	MTimeArray times[6];
+	MDoubleArray values[6];
+
+	for (int32_t frame = anm.frame_start(), frame_end = anm.frame_end();
+			frame < frame_end; ++frame) {
+		double time = frame/fps;
+
+		fvector3 offs, rot;
+		anm.evaluate(float(time), offs, rot);
+
+		append_key(times[0], values[0], time, MDistance(offs.x, MDistance::kMeters).asCentimeters());
+		append_key(times[1], values[1], time, MDistance(offs.y, MDistance::kMeters).asCentimeters());
+		append_key(times[2], values[2], time, MDistance(-offs.z, MDistance::kMeters).asCentimeters());
+
+		MEulerRotation maya_rot(-rot.x, -rot.y, rot.z, MEulerRotation::kZXY);
+		maya_rot.reorderIt(MEulerRotation::kXYZ);
+		append_key(times[3], values[3], time, maya_rot.x);
+		append_key(times[4], values[4], time, maya_rot.y);
+		append_key(times[5], values[5], time, maya_rot.z);
+	}
+
+	static const MString k_plug_names[6] = { "tx", "ty", "tz", "rx", "ry", "rz" };
+	for (uint_fast32_t i = 6; i != 0;) {
+		--i;
+		MFnAnimCurve curve_fn;
+		MObject curve_obj = curve_fn.create(i >= 3 ?
+				MFnAnimCurve::kAnimCurveTA : MFnAnimCurve::kAnimCurveTL,
+				0, &status);
+		CHECK_MSTATUS(status);
+		status = curve_fn.addKeys(&times[i], &values[i],
+				MFnAnimCurve::kTangentStep, MFnAnimCurve::kTangentStep);
+		CHECK_MSTATUS(status);
+		MPlug plug = transform_fn.findPlug(k_plug_names[i], true, &status);
+		CHECK_MSTATUS(status);
+		MFnDependencyNode curve_dep_fn(curve_obj);
+		MPlug output_plug = curve_dep_fn.findPlug("output", true, &status);
+		CHECK_MSTATUS(status);
+		MDGModifier dg_modifier;
+		status = dg_modifier.connect(output_plug, plug);
+		CHECK_MSTATUS(status);
+		dg_modifier.doIt();
+	}
+
+	msg("xray_re: imported anm motion %s onto %s", anm.name().c_str(), transform_fn.name().asChar());
+	MGlobal::displayInfo(MString("xray_re: imported anm motion ") + anm.name().c_str() +
+		" onto " + transform_fn.name());
+
+	return MS::kSuccess;
+}
+
 MStatus maya_anm_writer::writer(const MFileObject& file, const MString& options, FileAccessMode mode)
 {
 	
@@ -487,7 +849,11 @@ MStatus maya_anm_writer::writer(const MFileObject& file, const MString& options,
 	return maya_export_tools().export_anm(file.resolvedFullName().asChar(), mode == kExportActiveAccessMode);
 }
 
+bool maya_anm_writer::haveReadMethod() const { return true; }
+
 bool maya_anm_writer::haveWriteMethod() const { return true; }
+
+bool maya_anm_writer::canBeOpened() const { return true; }
 
 MString maya_anm_writer::defaultExtension() const { return MString("anm"); }
 
@@ -520,13 +886,15 @@ MStatus initializePlugin(MObject obj)
 	MFnPlugin plugin_fn(obj, PLUGIN_VENDOR, PLUGIN_VERSION);
 	if (!(status = maya_xray_material::initialize(plugin_fn)))
 		return status;
-	if (!(status = plugin_fn.registerFileTranslator(object_translator, "", maya_object_translator::creator, "xray_re_object_translator_options", "", true)))
+	if (!(status = plugin_fn.registerFileTranslator(object_reader, "", maya_object_reader::creator, "xray_re_object_import_options", "", true)))
 		return status;
-	if (!(status = plugin_fn.registerFileTranslator(skl_object_writer, "", maya_skl_object_writer::creator, "xray_re_object_translator_options", "", true)))
+	if (!(status = plugin_fn.registerFileTranslator(object_writer, "", maya_object_writer::creator, "xray_re_object_export_options", "", true)))
+		return status;
+	if (!(status = plugin_fn.registerFileTranslator(skl_object_writer, "", maya_skl_object_writer::creator, "xray_re_object_export_options", "", true)))
 		return status;
 	if (!(status = plugin_fn.registerFileTranslator(dm_reader, "", maya_dm_reader::creator, "", "", true)))
 		return status;
-	if (!(status = plugin_fn.registerFileTranslator(ogf_reader, "", maya_ogf_reader::creator, "", "", true)))
+	if (!(status = plugin_fn.registerFileTranslator(ogf_reader, "", maya_ogf_reader::creator, "xray_re_object_import_options", "", true)))
 		return status;
 	if (!(status = plugin_fn.registerFileTranslator(omf_reader, "", maya_omf_reader::creator, "", "", true)))
 		return status;
@@ -544,7 +912,8 @@ MStatus uninitializePlugin(MObject obj)
 {
 	MFnPlugin plugin_fn(obj);
 	maya_xray_material::uninitialize(plugin_fn);
-	plugin_fn.deregisterFileTranslator(object_translator);
+	plugin_fn.deregisterFileTranslator(object_reader);
+	plugin_fn.deregisterFileTranslator(object_writer);
 	plugin_fn.deregisterFileTranslator(skl_object_writer);
 	plugin_fn.deregisterFileTranslator(dm_reader);
 	plugin_fn.deregisterFileTranslator(ogf_reader);

--- a/src/plugins/Maya/xray_re_object_export_options.mel
+++ b/src/plugins/Maya/xray_re_object_export_options.mel
@@ -1,4 +1,4 @@
-global proc int xray_re_object_translator_options(string $parent, string $action, string $options, string $callback)
+global proc int xray_re_object_export_options(string $parent, string $action, string $options, string $callback)
 {
 	string $sdk_ver_params[] = { "1850", "0.4", "0.6"};
 	string $sdk_ver_names[] =  { "ver_1850", "ver_0_4", "ver_0_6" };

--- a/src/plugins/Maya/xray_re_object_import_options.mel
+++ b/src/plugins/Maya/xray_re_object_import_options.mel
@@ -1,0 +1,74 @@
+global proc int xray_re_object_import_options(string $parent, string $action, string $options, string $callback)
+{
+	int $i;
+	string $smoothing_params[] = { "normals", "soc", "cscop" };
+	string $smoothing_names[]  = { "smoothing_normals", "smoothing_soc", "smoothing_cscop" };
+	string $smoothing_labels[] = { "Normals", "SoC", "CS/CoP" };
+	int $j;
+
+	if($action == "post")
+	{
+		setParent $parent;
+		columnLayout -adj true;
+
+		checkBox -label "Replace selected mesh" "attach_to_selection";
+		checkBox -label "Split mesh into parts" -value true "split_parts";
+
+		text -label "Smoothing:" -align "left";
+		radioCollection "smoothing_mode";
+		for($i = 0; $i < size($smoothing_params); $i++)
+			radioButton -label $smoothing_labels[$i] $smoothing_names[$i];
+		radioCollection -edit -select "smoothing_normals" "smoothing_mode";
+
+		string $params[];
+		tokenize($options, ";", $params);
+		for($i = 0; $i < size($params); $i++)
+		{
+			string $kv[];
+			tokenize($params[$i], "=", $kv);
+
+			if(size($kv) < 3)
+				continue;
+
+			if($kv[0] == "attach_to_selection")
+				if($kv[1] == "true")
+					checkBox -edit -value true "attach_to_selection";
+				else
+					checkBox -edit -value false "attach_to_selection";
+
+			if($kv[0] == "split_parts")
+				if($kv[1] == "true")
+					checkBox -edit -value true "split_parts";
+				else
+					checkBox -edit -value false "split_parts";
+
+			if($kv[0] == "smoothing_mode")
+				for($j = 0; $j < size($smoothing_params); $j++)
+					if($smoothing_params[$j] == $kv[1])
+						radioCollection -edit -select $smoothing_names[$j] "smoothing_mode";
+		}
+	}
+	else if($action == "query")
+	{
+		$options = "";
+
+		if(`checkBox -q -value "attach_to_selection"`)
+			$options += "attach_to_selection=true;";
+		else
+			$options += "attach_to_selection=false;";
+
+		if(`checkBox -q -value "split_parts"`)
+			$options += "split_parts=true;";
+		else
+			$options += "split_parts=false;";
+
+		string $selected = `radioCollection -q -sl "smoothing_mode"`;
+		for($i = 0; $i < size($smoothing_names); $i++)
+			if($smoothing_names[$i] == $selected)
+				$options += "smoothing_mode=" + $smoothing_params[$i] + ";";
+
+		eval($callback + " \"" + $options + "\"");
+	}
+
+	return 1;
+}

--- a/src/plugins/PCore/xr_bone.cxx
+++ b/src/plugins/PCore/xr_bone.cxx
@@ -53,40 +53,37 @@ void xr_bone::load_0(xr_reader& r)
 	r.r_fvector3(m_bind_rotate);
 	m_bind_length = r.r_float();
 	std::swap(m_bind_offset.x, m_bind_offset.y);
-
-	// FIXME: reset other fields
-	xr_not_implemented();
 }
 
 void xr_bone::load_data(xr_reader& r)
 {
-	if (!r.find_chunk(BONE_CHUNK_DEF, 0, false))
-		xr_not_expected();
-	r.r_sz(m_name);
-	r.debug_find_chunk();
+	if (r.find_chunk(BONE_CHUNK_DEF, 0, false)) {
+		r.r_sz(m_name);
+		r.debug_find_chunk();
+	}
 
-	if (!r.find_chunk(BONE_CHUNK_MATERIAL))
-		xr_not_expected();
-	r.r_sz(m_gamemtl);
-	r.debug_find_chunk();
+	if (r.find_chunk(BONE_CHUNK_MATERIAL)) {
+		r.r_sz(m_gamemtl);
+		r.debug_find_chunk();
+	}
 
-	if (!r.find_chunk(BONE_CHUNK_SHAPE))
-		xr_not_expected();
-	r.r<s_bone_shape>(m_shape);
-	r.debug_find_chunk();
+	if (r.find_chunk(BONE_CHUNK_SHAPE)) {
+		r.r<s_bone_shape>(m_shape);
+		r.debug_find_chunk();
+	}
 
 	if (r.find_chunk(BONE_CHUNK_IK_FLAGS)) {
 		m_joint_ik_data.ik_flags = r.r_u32();
 		r.debug_find_chunk();
 	}
 
-	if (!r.find_chunk(BONE_CHUNK_IK_JOINT))
-		xr_not_expected();
-	m_joint_ik_data.type = r.r_u32();
-	r.r_cseq<s_joint_limit>(3, m_joint_ik_data.limits);
-	m_joint_ik_data.spring_factor = r.r_float();
-	m_joint_ik_data.damping_factor = r.r_float();
-	r.debug_find_chunk();
+	if (r.find_chunk(BONE_CHUNK_IK_JOINT)) {
+		m_joint_ik_data.type = r.r_u32();
+		r.r_cseq<s_joint_limit>(3, m_joint_ik_data.limits);
+		m_joint_ik_data.spring_factor = r.r_float();
+		m_joint_ik_data.damping_factor = r.r_float();
+		r.debug_find_chunk();
+	}
 
 	if (r.find_chunk(BONE_CHUNK_BREAK_PARAMS)) {
 		m_joint_ik_data.break_force = r.r_float();

--- a/src/plugins/PCore/xr_mesh.cxx
+++ b/src/plugins/PCore/xr_mesh.cxx
@@ -281,7 +281,7 @@ void xr_mesh::load(xr_reader& r, xr_object& object)
 
 	if ((size = r.find_chunk(EMESH_CHUNK_VNORMALS))) {
 		xr_assert(size == m_faces.size() * 3 * sizeof(fvector3));
-		r.r_seq(m_faces.size() * 3, m_vertex_normals);
+		r.r_seq(m_faces.size() * 3, m_corner_normals);
 		r.debug_find_chunk();
 	}
 
@@ -361,7 +361,13 @@ void xr_mesh::save(xr_writer& w) const
 		w.close_chunk();
 	}
 
-	if (!m_vertex_normals.empty()) 
+	if (!m_corner_normals.empty()) 
+	{
+		w.open_chunk(EMESH_CHUNK_VNORMALS);
+		w.w_seq(m_corner_normals);
+		w.close_chunk();
+	}
+	else if (!m_vertex_normals.empty()) 
 	{
 		w.open_chunk(EMESH_CHUNK_VNORMALS);
 		w.w_seq(m_vertex_normals);

--- a/src/plugins/PCore/xr_object.cxx
+++ b/src/plugins/PCore/xr_object.cxx
@@ -168,7 +168,7 @@ void xr_object::load_object(xr_reader& r)
 		s->r_chunks(m_bones, xr_reader::f_r_new<xr_bone>(&xr_bone::load_1));
 		r.close_chunk(s);
 	} else if (r.find_chunk(EOBJ_CHUNK_BONES_0)) {
-		s->r_seq(r.r_u32(), m_bones, xr_reader::f_r_new<xr_bone>(&xr_bone::load_0));
+		r.r_seq(r.r_u32(), m_bones, xr_reader::f_r_new<xr_bone>(&xr_bone::load_0));
 		r.debug_find_chunk();
 	}
 	setup_bones();


### PR DESCRIPTION
### Proposed changes / Предлагаемые изменения

1) Добавил флаг при импорте object и ogf "Split mesh into parts" (включен по дефолту), который разделяет меш по материалам (при drag and drop будет импортироваться разбитый меш по материалам). 
2) Добавил флаги выбора сглаживания при импорте ogf и object "soc", "cs/cop", "normals" (при drag and drop будет импортироваться normals, а также включен по дефолту). 
3) Добавил флаг при импорте object и ogf "Replace selected mesh". Этот флаг заменяет меш в анимации, на случай если нужно посмотреть хват, или анимация смотрятся на других руках (например экзоскелет, голые руки), но работать в этой сцене после не рекомендуется, лучше сохранить и откатиться до замены. 
4) Добавил импорт anm.
5) Пофиксил сглаживание при импорте ogf.
6) Пофиксил вылет при импорте object, который был экспортирован из Blender. 
7) Пофиксил вылет, который возникал во время экспорта, если на 1 вертекс привязано больше 6 костей.

### Testing / Тестирование

- [x] Manual testing / Ручное тестирование

### Agreements / Согласия

- I agree to follow this project's [__Contributing Guidelines__](../CONTRIBUTING.md) /
Я согласен(-на) следовать [__Рекомендациям по внесению вклада в этот проект__](../CONTRIBUTING.rus.md)
- I agree to follow this project's [__Code of Conduct__](../CODE_OF_CONDUCT.md) /
Я согласен(-на) следовать [__Кодексу поведения этого проекта__](../CODE_OF_CONDUCT.rus.md)
