### PR TITLE
Add prepend channel for item descriptions

### DIFF
--- a/src/xrGame/inventory_item.cpp
+++ b/src/xrGame/inventory_item.cpp
@@ -186,11 +186,40 @@ void CInventoryItem::SetAdditionalDescription(const char* additionalDescription)
 {
 	m_AdditionalDescription = additionalDescription;
 	m_IsUsedAdditionalDescription = xr_strcmp(m_AdditionalDescription, "") != 0;
+	RebuildExtendedDescription();
+}
+
+void CInventoryItem::SetPrependDescription(const char* prependDescription)
+{
+	m_PrependDescription = prependDescription ? prependDescription : "";
+	m_IsUsedPrependDescription = prependDescription && prependDescription[0];
+	RebuildExtendedDescription();
+}
+
+void CInventoryItem::RebuildExtendedDescription()
+{
+	xr_string description;
+
+	auto appendDescriptionBlock = [&description](const char* text)
+	{
+		if (!text || !text[0])
+			return;
+
+		if (!description.empty())
+			description += "\\n\\n";
+
+		description += text;
+	};
+
+	if (m_IsUsedPrependDescription)
+		appendDescriptionBlock(m_PrependDescription.c_str());
+
+	appendDescriptionBlock(m_Description.c_str());
 
 	if (m_IsUsedAdditionalDescription)
-	{
-		m_ExtendedUnionDescription = make_string<const char*>("%s\\n\\n%s", m_Description.c_str(), m_AdditionalDescription.c_str());
-	}
+		appendDescriptionBlock(m_AdditionalDescription.c_str());
+
+	m_ExtendedUnionDescription = description.c_str();
 }
 
 CInventoryItem::EInvCellAnchor CInventoryItem::ParseInvCellAnchor(const char* value)
@@ -280,6 +309,9 @@ void CInventoryItem::RefreshTranslations()
 	{
 		m_Description = g_pStringTable->translate(pSettings->r_string(section, "description"));
 	}
+
+	if (IsUsedExtendedDescription())
+		RebuildExtendedDescription();
 }
 
 void CInventoryItem::ChangeCondition(float fDeltaCondition)

--- a/src/xrGame/inventory_item.h
+++ b/src/xrGame/inventory_item.h
@@ -114,11 +114,16 @@ public:
 	void RefreshTranslations();
 
 	// Дополнение описания предмета для кастомизации через скрипты к основному описанию в UIItemInfo.cpp
+	void RebuildExtendedDescription();
 	void SetAdditionalDescription(const char* additionalDescription);
+	void SetPrependDescription(const char* prependDescription);
 	bool IsDrawCost() { return m_draw_cost; }
 	void UnsetAdditionalDescription() { SetAdditionalDescription(""); }
 	bool IsUsedAdditionalDescription() const { return m_IsUsedAdditionalDescription; }
+	bool IsUsedPrependDescription() const { return m_IsUsedPrependDescription; }
+	bool IsUsedExtendedDescription() const { return m_IsUsedPrependDescription || m_IsUsedAdditionalDescription; }
 	const char* GetAdditionalDescription() const { return m_AdditionalDescription.c_str(); }
+	const char* GetPrependDescription() const { return m_PrependDescription.c_str(); }
 	shared_str GetExtendedUnionDescription() const { return m_ExtendedUnionDescription; }
 
 	const char* NameItem() const { return m_name.c_str(); }
@@ -274,8 +279,10 @@ protected:
 	float m_weight = 0.0f;
 	float m_fCondition = 1.0f;
 	shared_str m_Description;
+	shared_str m_PrependDescription;
 	shared_str m_AdditionalDescription;
 	shared_str m_ExtendedUnionDescription;
+	bool m_IsUsedPrependDescription = false;
 	bool m_IsUsedAdditionalDescription = false;
 protected:
 	ALife::_TIME_ID m_dwItemIndependencyTime;

--- a/src/xrGame/script_game_object.cpp
+++ b/src/xrGame/script_game_object.cpp
@@ -566,7 +566,35 @@ bool CScriptGameObject::IsItemUsedAdditionalDescription()
 {
 	if (CInventoryItem* inventory_item = object().cast_inventory_item())
 	{
-		inventory_item->IsUsedAdditionalDescription();
+		return inventory_item->IsUsedAdditionalDescription();
+	}
+
+	return false;
+}
+
+const char* CScriptGameObject::GetItemPrependDescription()
+{
+	if (CInventoryItem* inventory_item = object().cast_inventory_item())
+	{
+		return inventory_item->GetPrependDescription();
+	}
+
+	return "";
+}
+
+void CScriptGameObject::SetItemPrependDescription(const char* prependDescription)
+{
+	if (CInventoryItem* inventory_item = object().cast_inventory_item())
+	{
+		inventory_item->SetPrependDescription(prependDescription);
+	}
+}
+
+bool CScriptGameObject::IsItemUsedPrependDescription()
+{
+	if (CInventoryItem* inventory_item = object().cast_inventory_item())
+	{
+		return inventory_item->IsUsedPrependDescription();
 	}
 
 	return false;

--- a/src/xrGame/script_game_object.h
+++ b/src/xrGame/script_game_object.h
@@ -461,6 +461,9 @@ public:
 			void				SetItemAdditionalDescription(const char* additionalDescription);
 			void				UnsetItemAdditionalDescription();
 			bool				IsItemUsedAdditionalDescription();
+			const char*				GetItemPrependDescription();
+			void				SetItemPrependDescription(const char* prependDescription);
+			bool				IsItemUsedPrependDescription();
 
 			u32					GetAmmoElapsed		();
 

--- a/src/xrGame/script_game_object_script2.cpp
+++ b/src/xrGame/script_game_object_script2.cpp
@@ -153,6 +153,9 @@ class_<CScriptGameObject> script_register_game_object1(class_<CScriptGameObject>
 		.def("set_item_additional_description", &CScriptGameObject::SetItemAdditionalDescription)
 		.def("unset_item_additional_description", &CScriptGameObject::UnsetItemAdditionalDescription)
 		.def("is_item_used_additional_description", &CScriptGameObject::IsItemUsedAdditionalDescription)
+		.def("get_item_prepend_description", &CScriptGameObject::GetItemPrependDescription)
+		.def("set_item_prepend_description", &CScriptGameObject::SetItemPrependDescription)
+		.def("is_item_used_prepend_description", &CScriptGameObject::IsItemUsedPrependDescription)
 
 		.def("get_ammo_in_magazine",		&CScriptGameObject::GetAmmoElapsed)
 		.def("get_ammo_in_magazine_and_chamber", &CScriptGameObject::GetAmmoElapsedWithChamber) //FFx0001++

--- a/src/xrGame/ui/UIItemInfo.cpp
+++ b/src/xrGame/ui/UIItemInfo.cpp
@@ -356,7 +356,7 @@ void CUIItemInfo::InitItem(CUICellItem* pCellItem, CInventoryItem* pCompareItem,
 			pItem->SetFont						(m_desc_info.pDescFont);
 			pItem->SetWidth						(UIDesc->GetDesiredChildWidth());
 			pItem->SetTextComplexMode			(true);
-			pItem->SetText(pInvItem->IsUsedAdditionalDescription() ? *pInvItem->GetExtendedUnionDescription() : *pInvItem->ItemDescription());
+			pItem->SetText(pInvItem->IsUsedExtendedDescription() ? *pInvItem->GetExtendedUnionDescription() : *pInvItem->ItemDescription());
 			pItem->AdjustHeightToText			();
 			UIDesc->AddWindow					(pItem, true);
 		}


### PR DESCRIPTION
## Summary
- add a transient prepend-description channel for inventory items
- compose item text as prepend, base description, then the existing additional description
- expose get/set/unset/is-used prepend methods to Lua
- fix the existing is_item_used_additional_description wrapper to return the actual state

## Compatibility
- keep additional_description semantics unchanged as a postscript
- do not add serialized state; prepend text is recalculated by scripts
- join only non-empty blocks with a double line break

## Testing
- cmake --build build --config RelWithDebInfo --target xrGame --parallel