### PR TITLE
Исправить вылет диспетчера спавна при пустом inv_name

### DIFF
--- a/src/xrGame/ImUtils/SpawnManager.cpp
+++ b/src/xrGame/ImUtils/SpawnManager.cpp
@@ -1375,6 +1375,8 @@ Section FilterSectionsWithSearch(const Section& sections, const char* searchBuff
 			xr_string lowerSectionName = xr_strlwr_rus(sectionKey);
 
 			const char* rawName = READ_IF_EXISTS(pSettings, r_string, sectionKey, "inv_name", sectionKey);
+			if (!rawName || !*rawName)
+				rawName = sectionKey;
 
 			xr_string lowerTranslated = xr_strlwr_rus(g_pStringTable->translate(rawName).c_str());
 


### PR DESCRIPTION
## Причина

В `FilterSectionsWithSearch` значение `inv_name` считывалось через `READ_IF_EXISTS`. Макрос выбирает `r_string`, если ключ присутствует, но пустой `inv_name =` хранится как `nullptr`. Затем `nullptr` доходил до создания `xr_string`, что приводило к `0xC0000005` в `std::char_traits<char>::length`.

## Исправление

Если `inv_name` пуст или равен `nullptr`, фильтр использует имя секции. Это сохраняет существующее поведение для секций без `inv_name` и не меняет обработку корректных локализованных имён.

## Проверка

- До исправления локальная регрессионная проверка подтверждала отсутствие защиты.
- После исправления регрессионная проверка проходит.
- `git diff --check` проходит.
- `cmake --build build-check --config RelWithDebInfo --target xrGame --parallel 4` проходит.