### PR TITLE
Добавить независимую дальность полной детализации для R4

### DIFF
--- a/src/Layers/xrRender/r__dsgraph_build.cpp
+++ b/src/Layers/xrRender/r__dsgraph_build.cpp
@@ -47,13 +47,13 @@ ICF bool R4FullDetailRejectStatic(dxRender_Visual* pVisual)
 	}
 
 	const float far_plane = g_pGamePersistent->Environment().CurrentEnv->far_plane;
-	const float full_detail_distance = _max(100.f, far_plane * ps_r4_full_detail_distance_scale);
+	const float full_detail_distance = std::max(100.f, far_plane * ps_r4_full_detail_distance_scale);
 	const float dist_sq = Device.vCameraPosition.distance_to_sqr(pVisual->vis.sphere.P) + EPS;
 	const float nearest_distance = _sqrt(dist_sq) - pVisual->vis.sphere.R;
 	if (nearest_distance <= full_detail_distance)
 		return false;
 
-	const float transition_range = _max(1.f, far_plane - full_detail_distance);
+	const float transition_range = std::max(1.f, far_plane - full_detail_distance);
 	const float transition = clampr((nearest_distance - full_detail_distance) / transition_range, 0.f, 1.f);
 	const float ssa = pVisual->vis.sphere.R / dist_sq;
 	return ssa <= r_ssaDISCARD * (1.f + transition * 11.f);

--- a/src/Layers/xrRender/r__dsgraph_build.cpp
+++ b/src/Layers/xrRender/r__dsgraph_build.cpp
@@ -26,6 +26,42 @@ float r_ssaGLOD_start;
 float r_ssaGLOD_end;
 float r_ssaHZBvsTEX;
 
+ICF bool R4FullDetailRejectStatic(dxRender_Visual* pVisual)
+{
+#if RENDER == R_R4
+	if (ps_r4_full_detail_distance_scale >= 1.f ||
+		RImplementation.phase != CRender::PHASE_NORMAL ||
+		pVisual->IsIgnoreOptimize || !g_pGamePersistent ||
+		!g_pGamePersistent->Environment().CurrentEnv)
+		return false;
+
+	switch (pVisual->Type)
+	{
+	case MT_LOD:
+	case MT_LOD1:
+	case MT_LOD2:
+	case MT_LOD3:
+	case MT_LOD4:
+	case MT_MESH_LODS:
+		return false;
+	}
+
+	const float far_plane = g_pGamePersistent->Environment().CurrentEnv->far_plane;
+	const float full_detail_distance = _max(100.f, far_plane * ps_r4_full_detail_distance_scale);
+	const float dist_sq = Device.vCameraPosition.distance_to_sqr(pVisual->vis.sphere.P) + EPS;
+	const float nearest_distance = _sqrt(dist_sq) - pVisual->vis.sphere.R;
+	if (nearest_distance <= full_detail_distance)
+		return false;
+
+	const float transition_range = _max(1.f, far_plane - full_detail_distance);
+	const float transition = clampr((nearest_distance - full_detail_distance) / transition_range, 0.f, 1.f);
+	const float ssa = pVisual->vis.sphere.R / dist_sq;
+	return ssa <= r_ssaDISCARD * (1.f + transition * 11.f);
+#else
+	return false;
+#endif
+}
+
 // Aproximate, adjusted by fov, distance from camera to position (For right work when looking though binoculars and scopes)
 ICF float GetDistFromCamera(const Fvector& from_position)
 {
@@ -659,6 +695,8 @@ void add_leafs_Static(xr_vector<dxRender_Visual*>& children)
 	for(dxRender_Visual* pVisual : children)
 	{
 		vis_data& vis = pVisual->vis;
+		if (R4FullDetailRejectStatic(pVisual))
+			continue;
 
 #if RENDER!=R_R1
 		if (RI.phase == CRender::PHASE_NORMAL)
@@ -745,6 +783,9 @@ void R_dsgraph_structure::add_Static(dxRender_Visual *pVisual, u32 planes)
 	}
 
 	if (fcvNone==VIS)		
+		return;
+
+	if (R4FullDetailRejectStatic(pVisual))
 		return;
 #if RENDER!=R_R1
 	if(phase==CRender::PHASE_NORMAL)

--- a/src/Layers/xrRender/xrRender_console.cpp
+++ b/src/Layers/xrRender/xrRender_console.cpp
@@ -233,6 +233,7 @@ int			ps_r2_dhemi_count			= 5;				// 5
 int			ps_r2_wait_sleep			= 0;
 
 float		ps_r4_mblur_power = 0.25f;
+float		ps_r4_full_detail_distance_scale = 1.f;
 
 float		ps_r2_lt_smooth				= 1.f;				// 1.f
 float		ps_r2_slight_fade			= 0.6f;				// 1.f
@@ -824,6 +825,7 @@ void		xrRender_initconsole	()
 	CMD3(CCC_Token, "r__screenshot_format", &ps_screenshot_format, screenshot_format_token);
 	CMD3(CCC_Token, "r4_mblur_quality", &ps_r4_mblur_quality, mblur_quality_token);
 	CMD4(CCC_Float, "r4_mblur_power", &ps_r4_mblur_power, 0.0f, 1.0f);
+	CMD4(CCC_Float, "r4_full_detail_distance_scale", &ps_r4_full_detail_distance_scale, 0.1f, 1.0f);
 
 	CMD3(CCC_Mask32, "r1_use_terrain_mask", &ps_r1_flags, R1FLAG_TERRAIN_MASK);
 

--- a/src/Layers/xrRender/xrRender_console.cpp
+++ b/src/Layers/xrRender/xrRender_console.cpp
@@ -233,7 +233,7 @@ int			ps_r2_dhemi_count			= 5;				// 5
 int			ps_r2_wait_sleep			= 0;
 
 float		ps_r4_mblur_power = 0.25f;
-float		ps_r4_full_detail_distance_scale = 1.f;
+float		ps_r4_full_detail_distance_scale = 0.5f;
 
 float		ps_r2_lt_smooth				= 1.f;				// 1.f
 float		ps_r2_slight_fade			= 0.6f;				// 1.f

--- a/src/Layers/xrRender/xrRender_console.h
+++ b/src/Layers/xrRender/xrRender_console.h
@@ -168,6 +168,7 @@ extern ECORE_API int r_debug_render_depth;
 
 extern ECORE_API u32 ps_r4_mblur_quality;
 extern ECORE_API float ps_r4_mblur_power;
+extern ECORE_API float ps_r4_full_detail_distance_scale;
 
 enum
 {

--- a/src/Layers/xrRenderPC_R4/r4_R_render.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_R_render.cpp
@@ -148,11 +148,25 @@ void CRender::render_main	(bool deffered, bool zfill)
 			}
 		}
 		PROF_EVENT("add_dynamic")
+		const bool use_full_detail_distance = ps_r4_full_detail_distance_scale < 1.f;
+		const float full_detail_distance = use_full_detail_distance ?
+			_max(100.f, g_pGamePersistent->Environment().CurrentEnv->far_plane * ps_r4_full_detail_distance_scale) : 0.f;
 		// Traverse frustums
 		for (u32 o_it=0; o_it<lstRenderablesMain.size(); o_it++)
 		{
 			ISpatial*	spatial	= lstRenderablesMain[o_it].get();
-			if	(0==spatial) continue; spatial->spatial_updatesector();
+			if	(0==spatial) continue;
+
+			if (use_full_detail_distance &&
+				Device.vCameraPosition.distance_to_sqr(spatial->sphere.P) > _sqr(full_detail_distance + spatial->sphere.R))
+			{
+				light* L = (spatial->type & ESPATIAL_TYPE::LIGHTSOURCE) != ESPATIAL_TYPE::NONE ?
+					(light*)spatial->dcast_Light() : nullptr;
+				if (!L || !L->flags.bHudMode)
+					continue;
+			}
+
+			spatial->spatial_updatesector();
 			CSector* sector = (CSector*)spatial->sector;
 			if	(0==sector) continue;
 

--- a/src/Layers/xrRenderPC_R4/r4_R_render.cpp
+++ b/src/Layers/xrRenderPC_R4/r4_R_render.cpp
@@ -150,7 +150,7 @@ void CRender::render_main	(bool deffered, bool zfill)
 		PROF_EVENT("add_dynamic")
 		const bool use_full_detail_distance = ps_r4_full_detail_distance_scale < 1.f;
 		const float full_detail_distance = use_full_detail_distance ?
-			_max(100.f, g_pGamePersistent->Environment().CurrentEnv->far_plane * ps_r4_full_detail_distance_scale) : 0.f;
+			std::max(100.f, g_pGamePersistent->Environment().CurrentEnv->far_plane * ps_r4_full_detail_distance_scale) : 0.f;
 		// Traverse frustums
 		for (u32 o_it=0; o_it<lstRenderablesMain.size(); o_it++)
 		{


### PR DESCRIPTION
### Предлагаемые изменения

- Добавлен параметр `r4_full_detail_distance_scale`.
- Дальние динамические объекты отсекаются до обновления сектора и проверки HOM.
- За пределами полной детализации постепенно повышается порог SSA для мелкой статической геометрии.
- `0.5` включает протестированный производительный режим; `1.0` оставляет прежнюю глубину полной детализации.

Формула: `full_detail_distance = far_plane * r4_full_detail_distance_scale`.

### Ассоциированные проблемы

- Нет.

### Тестирование

- [x] Исходная формула вручную проверена в R4 при `0.5` и `1.0`.

### Согласия

- С правилами участия и кодексом поведения согласен.